### PR TITLE
Document meeting roles

### DIFF
--- a/meetings/examples/notes-email.md
+++ b/meetings/examples/notes-email.md
@@ -9,8 +9,8 @@ Russ
 This e-mail, like all written and spoken communications within the InnerSource Commons,
 is subject to the Chatham House Rule which states that information may be freely used so long as there is no attribution.      
 
-Note: We've been interpreting the Chatham House Rule to say that we can safely share these detailed notes within the InnerSource Commons (innersource-commons@googlegroups.com);
-so this distribution list for the notes is only to members of the InnerSource Commons.
+Note: We've been interpreting the Chatham House Rule to say that we can safely share these detailed notes within the InnerSource Commons (innersource-commons@googlegroups.com)
+This distribution list for the notes is only to members of the InnerSource Commons.
 Accordingly, **please do not distribute these notes beyond the members of the InnerSource Commons**.      
     
 ## Chatham House Rule      

--- a/meetings/examples/notes-email.md
+++ b/meetings/examples/notes-email.md
@@ -1,0 +1,60 @@
+Hi, everyone, thanks for coming today.  Here are the notes (also in the [Google doc])!   
+
+Russ   
+
+- - -  
+
+# DISCLAIMER      
+
+This e-mail, like all written and spoken communications within the InnerSource Commons,
+is subject to the Chatham House Rule which states that information may be freely used so long as there is no attribution.      
+
+Note: We've been interpreting the Chatham House Rule to say that we can safely share these detailed notes within the InnerSource Commons (innersource-commons@googlegroups.com);
+so this distribution list for the notes is only to members of the InnerSource Commons.
+Accordingly, **please do not distribute these notes beyond the members of the InnerSource Commons**.      
+    
+## Chatham House Rule      
+
+* https://www.chathamhouse.org/chatham-house-rule      
+
+- - -
+
+**Attendees**: Flo, Joe, Moe, Bo, Zoe
+
+**Salient Points**
+
+* Lorem ipsum dolor sit amet.
+* Consectetur adipiscing elit.
+* Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+* Ut enim ad minim veniam.
+* Quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+* Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+* Excepteur sint occaecat cupidatat non proident.
+* Sunt in culpa qui officia deserunt mollit anim id est laboru.
+
+**Assignments**
+
+* **Flo**
+
+  * Lorem ipsum dolor sit amet.
+  * Consectetur adipiscing elit.
+
+* **Joe**
+
+  * Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+* **Moe**
+
+  * Quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+  * Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+* **Bo**
+
+  * Excepteur sint occaecat cupidatat non proident.
+  * Sunt in culpa qui officia deserunt mollit anim id est laboru.
+
+* **Zoe**
+
+  * Ut enim ad minim veniam.
+ 
+[Google doc]: https://docs.google.com/document/d/1Lr-TlxG9_XuKdHf4JekgI4hIReIFIgH2pcER0Uw9M7g/edit?usp=sharing

--- a/meetings/roles.md
+++ b/meetings/roles.md
@@ -13,19 +13,19 @@ The roles are:
 The _Scheduler_ sends the calendar invite for the meeting.
 
 **Within 24 Hours of Previous Meeting**
-* [ ] Create an agenda document for the next meeting by copying [template][template] into the [learning path folder].
-* [ ] Open the document and follow the steps in _Do these things to set up this document_.
+* [ ] Create an agenda document for the next meeting by copying this [template][template] into the [learning path folder].
+* [ ] Open the document and follow the steps in the "_Do these things to set up this document_" section.
 * [ ] Send the calendar invite for the next meeting.
-The meeting invite must include:
+This invite must include:
 
   * Conference call info.
   * Comment-enabled link to the agenda document.
 
 ### Tips
 
-* The _Scribe_ should include the time of the meeting in the notes from the previous meeting. 
+* The _Scribe_ should have included the time of the meeting in the notes from the previous meeting. 
 * Include everyone from the previous meeting on the invite for the next meeting.
-An easy way to do this using _Outlook_ is to "Reply all by meeting" to the notes email from the previous meeting.
+An easy way to do this using _Outlook_ is to reply by meeting to the notes email from the previous meeting.
 * The title of the meeting should be "Inner Source Learning Path Working Session".
 * You can use your favorite corporate conference call system or create a Google Hangout.
 * Check out this [writeup][gdoc sharing] if you need help creating a comment-enabled link to the agenda document.
@@ -43,7 +43,7 @@ The _Crier_ reminds people in _Slack_ of the upcoming meeting.
 ### Tips
 
 * Ensure that the announcement has enough information for people to join the meeting _even if they don't have the calendar invite_.
-That means that at a minimum the announcement has the meeting day, time, and call info.
+That means at a minimum the announcement has the meeting day, time, and call info.
 * Try to make the announcement engaging so that even people that have not participated before may be interested in joining.
 * Here is an [example announcement][#learning-path announcement] in the #learning-path channel and [its share][#innersourcecommons share] in the #innersourcecommons channel.
 
@@ -52,7 +52,7 @@ That means that at a minimum the announcement has the meeting day, time, and cal
 
 The _Facilitator_ conducts the meeting so that all of the agenda items are finished within the allotted time.
 
-**Prior to Meeting**
+**Day Before Meeting**
 
 * [ ] Review the agenda and ensure that you are reasonably familiar with each item on it.
 
@@ -67,12 +67,12 @@ The _Facilitator_ conducts the meeting so that all of the agenda items are finis
 * The purpose of reviewing each agenda item is to generate actionable, assigned next steps.  Accordingly:
 
   * Guide the conversation towards understanding what is blocking the item's progression and what can be done to advance it.
-  * Strive for each task to be assigned to a volunteer from the call.
+  * Strive for each task to be assigned to a volunteer on the call.
   * When all such tasks have been assigned, move on to the next agenda item.
   
 * When reviewing the project board:
 
-  * Treat each issue in the **In Review** and and **In Progress** columns as if it were its own item on the agenda.
+  * Treat each issue in the **In Review** and **In Progress** columns as if it were its own item on the agenda.
   * The **Done** column does not need review.
   * Call out if anyone would like to review any issue in the **To Do** column.
   If so, then treat that issue like a regular agenda item.
@@ -89,7 +89,7 @@ The _Scribe_ takes and sends out the meeting notes.
 
 **Day Before Meeting**
 
-* [ ] Reserve time on your calendar to transcribe your meeting notes into the **Notes** section of the agenda document.
+* [ ] Reserve time on tomorrow's calendar to transcribe your meeting notes into the **Notes** section of the agenda document.
 This time should be scheduled as close as possible after the end of the meeting.
 
 **During Meeting**
@@ -100,8 +100,8 @@ This time should be scheduled as close as possible after the end of the meeting.
 **Within 24 Hours of Meeting**
 
 * [ ] Distill your copious notes into just what is needed to document the salient points and assignments of the meeting.
-Be sure that the time of next meeting is included.
-* [ ] Put these polished notes into the agenda document.
+Be sure to include the time of next meeting.
+* [ ] Put these polished notes into the **Notes** section of the agenda document.
 * [ ] Email the notes to everyone on the meeting invite.
 This email should include (in order):
 
@@ -116,6 +116,7 @@ This email should include (in order):
 Part of your service as _Scribe_ is to summarize the key points of what was said
 so that recipients don't need to wade through all of the conversation in order to understand its essentials.
 * Here is a [sample email].
+* An easy way to send the notes to everyone on the meeting invite is to "Reply all" to the invite.
  
 [template]: https://docs.google.com/document/d/16pTjdrihudETbt-WSzgRSJgkIL0xm8wLKMKsvRoEGxs/edit?usp=sharing
 [learning path folder]: https://drive.google.com/drive/u/1/folders/11EkhuLJqQDloNU1W6c-f2bbOYVTUorCU

--- a/meetings/roles.md
+++ b/meetings/roles.md
@@ -14,7 +14,7 @@ The _Scheduler_ sends the calendar invite for the meeting.
 
 **Within 24 Hours of Previous Meeting**
 * [ ] Create an agenda document for the next meeting by copying this [template][template] into the [learning path folder].
-* [ ] Open the document and follow the steps in the "_Do these things to set up this document_" section.
+* [ ] Open the document and follow the steps in the **Do these things to set up this document** section.
 * [ ] Send the calendar invite for the next meeting.
 This invite must include:
 
@@ -103,12 +103,15 @@ This time should be scheduled as close as possible after the end of the meeting.
 * [ ] Distill your copious notes into just what is needed to document the salient points and assignments of the meeting.
 Be sure to include the time of next meeting.
 * [ ] Put these polished notes into the **Notes** section of the agenda document.
+* [ ] Announce in the [#learning-path] channel that the notes are in the agenda document.
+In your announcement include a sharing link to the document itself.
 * [ ] Email the notes to everyone on the meeting invite.
 This email should include (in order):
 
   * Link to the agenda document where the notes are located.
   * Chatham House Rule disclaimer.
   * Copy/pasted notes from the agenda document.
+  
 
 ### Tips
 
@@ -116,6 +119,7 @@ This email should include (in order):
 * Make the notes clear and to the point.
 Part of your service as _Scribe_ is to summarize the key points of what was said
 so that recipients don't need to wade through all of the conversation in order to understand its essentials.
+* Here is a [sample notes announcement].
 * Here is a [sample email].
 * An easy way to send the notes to everyone on the meeting invite is to "Reply all" to the invite.
  
@@ -131,3 +135,4 @@ so that recipients don't need to wade through all of the conversation in order t
 [#learning-path announcement]: https://paypalflow.slack.com/archives/CARTU4XV2/p1553011676104100
 [#innersourcecommons share]: https://paypalflow.slack.com/archives/C0FJ7D2QH/p1553011694061300
 [sample email]: ./examples/notes-email.md
+[sample notes announcement]: https://paypalflow.slack.com/archives/CARTU4XV2/p1553120120110300

--- a/meetings/roles.md
+++ b/meetings/roles.md
@@ -1,0 +1,131 @@
+This document describes the various roles involved with running the meetings involved in the production of the learning path.
+All of these roles should be filled and completed for each meeting to be as successful as possible.
+The roles are:
+
+* [Scheduler]
+* [Crier]
+* [Facilitator]
+* [Scribe]
+
+<a name="scheduler"></a>
+## Scheduler
+
+The _Scheduler_ sends the calendar invite for the meeting.
+
+**Within 24 Hours of Previous Meeting**
+* [ ] Create an agenda document for the next meeting by copying [template][template] into the [learning path folder].
+* [ ] Open the document and follow the steps in _Do these things to set up this document_.
+* [ ] Send the calendar invite for the next meeting.
+The meeting invite must include:
+
+  * Conference call info.
+  * Comment-enabled link to the agenda document.
+
+### Tips
+
+* The _Scribe_ should include the time of the meeting in the notes from the previous meeting. 
+* Include everyone from the previous meeting on the invite for the next meeting.
+An easy way to do this using _Outlook_ is to "Reply all by meeting" to the notes email from the previous meeting.
+* The title of the meeting should be "Inner Source Learning Path Working Session".
+* You can use your favorite corporate conference call system or create a Google Hangout.
+* Check out this [writeup][gdoc sharing] if you need help creating a comment-enabled link to the agenda document.
+
+<a name="crier"></a>
+## Crier
+
+The _Crier_ reminds people in _Slack_ of the upcoming meeting.
+
+**About 24 Hours Before Meeting**
+
+* [ ] Announce the meeting in the [#learning-path] channel.
+* [ ] Share that announcement with the [#innersourcecommons] channel.
+
+### Tips
+
+* Ensure that the announcement has enough information for people to join the meeting _even if they don't have the calendar invite_.
+That means that at a minimum the announcement has the meeting day, time, and call info.
+* Try to make the announcement engaging so that even people that have not participated before may be interested in joining.
+* Here is an [example announcement][#learning-path announcement] in the #learning-path channel and [its share][#innersourcecommons share] in the #innersourcecommons channel.
+
+<a name="facilitator"></a>
+## Facilitator
+
+The _Facilitator_ conducts the meeting so that all of the agenda items are finished within the allotted time.
+
+**Prior to Meeting**
+
+* [ ] Review the agenda and ensure that you are reasonably familiar with each item on it.
+
+**During Meeting**
+
+* [ ] Facilitate the meeting according to the **Tips** below.
+
+### Tips
+
+* Have the agenda open and share your screen with the people on the call.
+* Guide the group through reviewing each agenda item from top to bottom.
+* The purpose of reviewing each agenda item is to generate actionable, assigned next steps.  Accordingly:
+
+  * Guide the conversation towards understanding what is blocking the item's progression and what can be done to advance it.
+  * Strive for each task to be assigned to a volunteer from the call.
+  * When all such tasks have been assigned, move on to the next agenda item.
+  
+* When reviewing the project board:
+
+  * Treat each issue in the **In Review** and and **In Progress** columns as if it were its own item on the agenda.
+  * The **Done** column does not need review.
+  * Call out if anyone would like to review any issue in the **To Do** column.
+  If so, then treat that issue like a regular agenda item.
+  If not, then no further discussion is needed.
+
+* Remember that it's OK to finish early.
+Once the agenda is complete the meeting is over.
+* At the close of the call thank everyone for participating.
+
+<a name="scribe"></a>
+## Scribe
+
+The _Scribe_ takes and sends out the meeting notes.
+
+**Day Before Meeting**
+
+* [ ] Reserve time on your calendar to transcribe your meeting notes into the **Notes** section of the agenda document.
+This time should be scheduled as close as possible after the end of the meeting.
+
+**During Meeting**
+
+* [ ] Note the first names of each meeting attendee.
+* [ ] Take copious notes to yourself of everything relating to the salient points and assignments of the meeting.
+
+**Within 24 Hours of Meeting**
+
+* [ ] Distill your copious notes into just what is needed to document the salient points and assignments of the meeting.
+Be sure that the time of next meeting is included.
+* [ ] Put these polished notes into the agenda document.
+* [ ] Email the notes to everyone on the meeting invite.
+This email should include (in order):
+
+  * Link to the agenda document where the notes are located.
+  * Chatham House Rule disclaimer.
+  * Copy/pasted notes from the agenda document.
+
+### Tips
+
+* Ensure that a regular attendee who is not at the meeting could understand what happened by the notes only.
+* Make the notes clear and to the point.
+Part of your service as _Scribe_ is to summarize the key points of what was said
+so that recipients don't need to wade through all of the conversation in order to understand its essentials.
+* Here is a [sample email].
+ 
+[template]: https://docs.google.com/document/d/16pTjdrihudETbt-WSzgRSJgkIL0xm8wLKMKsvRoEGxs/edit?usp=sharing
+[learning path folder]: https://drive.google.com/drive/u/1/folders/11EkhuLJqQDloNU1W6c-f2bbOYVTUorCU
+[#learning-path]: https://paypalflow.slack.com/messages/CARTU4XV2/
+[#innersourcecommons]: https://paypalflow.slack.com/messages/C0FJ7D2QH
+[Scheduler]: #scheduler
+[Crier]: #crier
+[Facilitator]: #facilitator
+[Scribe]: #scribe
+[gdoc sharing]: https://business.tutsplus.com/articles/everything-you-need-to-know-about-sharing-in-google-docs--cms-20676
+[#learning-path announcement]: https://paypalflow.slack.com/archives/CARTU4XV2/p1553011676104100
+[#innersourcecommons share]: https://paypalflow.slack.com/archives/C0FJ7D2QH/p1553011694061300
+[sample email]: ./examples/notes-email.md

--- a/meetings/roles.md
+++ b/meetings/roles.md
@@ -45,7 +45,8 @@ The _Crier_ reminds people in _Slack_ of the upcoming meeting.
 * Ensure that the announcement has enough information for people to join the meeting _even if they don't have the calendar invite_.
 That means at a minimum the announcement has the meeting day, time, and call info.
 * Try to make the announcement engaging so that even people that have not participated before may be interested in joining.
-* Here is an [example announcement][#learning-path announcement] in the #learning-path channel and [its share][#innersourcecommons share] in the #innersourcecommons channel.
+A good way to do that is to copy the agenda text from the invite into the announcement.
+* Here is an [example announcement][#learning-path announcement] in the [#learning-path] channel and [its share][#innersourcecommons share] in the [#innersourcecommons] channel.
 
 <a name="facilitator"></a>
 ## Facilitator

--- a/meetings/roles.md
+++ b/meetings/roles.md
@@ -25,7 +25,7 @@ This invite must include:
 
 * The _Scribe_ should have included the time of the meeting in the notes from the previous meeting. 
 * Include everyone from the previous meeting on the invite for the next meeting.
-An easy way to do this using _Outlook_ is to reply by meeting to the notes email from the previous meeting.
+An easy way to do this is to use the _Reply with meeting_ function to the notes email from the previous meeting.
 * The title of the meeting should be "Inner Source Learning Path Working Session".
 * You can use your favorite corporate conference call system or create a Google Hangout.
 * Check out this [writeup][gdoc sharing] if you need help creating a comment-enabled link to the agenda document.


### PR DESCRIPTION
* [This document](https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/meeting-roles/meetings/roles.md) describes everything that I am doing to run the meetings of the Inner Source Learning Path working group.
* The document partitions the activities involved in running a successful meeting into a set of loosely-coupled, highly cohesive roles.
* While I am happy to continue to fill all of these roles, I feel that as the working group matures it will make sense to share leadership with other members of the community via filling these meeting roles.