### PR TITLE
Addressed #39's decision for the introduction articles

### DIFF
--- a/introduction/01-introduction.md
+++ b/introduction/01-introduction.md
@@ -3,13 +3,13 @@ This accompanying text will appear as a part of the learning path (like [this ex
 
 # Introduction
 
-This Learning Path gives an introduction to inner source.
-Inner source is the application of open source practices and principles to software development within the enterprise.
-Inner source software remains proprietary to the company, but within it is open for anyone to use it and contribute to it.
+This Learning Path gives an introduction on how to use the InnerSource approach.
+InnerSource is the application of open source practices and principles to software development within the enterprise.
+InnerSource software remains proprietary to the company, but within it is open for anyone to use it and contribute to it.
 This strategy enables wide and effective collaboration, producing software that is responsive and nimble to the changing needs of its many internal stakeholders.
 
 
-This Learning Path teaches how to recognize situations that are good candidates for inner source.
-We'll outline at a high level how inner source can help in those situations.
-You'll become familiar with shared terms used when discussing inner source.
-We'll also enumerate the key principles upon-which inner source is based and the benefits seen when it is applied effectively.
+This Learning Path teaches how to recognize situations that are good candidates for the InnerSource approach.
+We'll outline at a high level how InnerSource can help in those situations.
+You'll become familiar with shared terms used when discussing InnerSource.
+We'll also enumerate the key principles upon-which InnerSource is based and the benefits seen when it is applied effectively.

--- a/introduction/02-problems-solved.md
+++ b/introduction/02-problems-solved.md
@@ -3,7 +3,7 @@ This accompanying text will appear as a part of the learning path (like [this ex
 
 # What Problems Does InnerSource Solve?
 
-Inner source encourages and rewards collaboration and code reuse with anyone, regardless of their position in a company's organizational structure.
+InnerSource encourages and rewards collaboration and code reuse with anyone, regardless of their position in a company's organizational structure.
 This approach differs from what is seen in traditional organizations where ideas and work product tend to stay trapped within the boundaries of the internal corporate hierarchy and its silos.
 Let's explore one situation that gives an example of this idea. 
 
@@ -33,10 +33,10 @@ It is still a drag on the team, though, because it necessarily diverts some of t
 Additionally, this option does not scale as there are only so many times that a consumer can escalate feature requests before damaging their credibility.
 Escalation is similarly disruptive (even more so) for the producing team, who are taken out of their normal workflow and prioritization methods to deal with the escalated feature request.
 
-This discussion sets the stage for inner source.
-Inner source applies to the same type of situation where a consuming team is unable to get what needs via feature request.
-Inner source provides a way for the teams to gain the benefits of _wait it out_, _workaround_, and _escalate_ without the associated drawbacks.
+This discussion sets the stage for InnerSource.
+InnerSource applies to the same type of situation where a consuming team is unable to get what needs via feature request.
+InnerSource provides a way for the teams to gain the benefits of _wait it out_, _workaround_, and _escalate_ without the associated drawbacks.
 
-Inner source also provides a general improvement to engineering culture as engineers have the chance to work with a wider variety of new technologies and people.
+InnerSource also provides a general improvement to engineering culture as engineers have the chance to work with a wider variety of new technologies and people.
 Developers mentor and learn from one another as they share ideas and solutions across organizational silos.
 Engineers and teams can reuse internal solutions to commodity problems, allowing them to focus on higher value streams of work for the organization.

--- a/introduction/03-how-works.md
+++ b/introduction/03-how-works.md
@@ -21,14 +21,14 @@ They're careful with the items in the house and follow the rules for the duratio
 They may hope for or expect a return invitation as long as they've been courteous and polite.
 These concepts around a home visit are a metaphor for the attitude and behaviors that teams should bring as one hosts another making a guest contribution to the codebase.
 
-Let's take a closer look at how the mechanics of the inner source process can work.
+Let's take a closer look at how the mechanics of the InnerSource process can work.
 To aid in this explanation, we'll name a few key individuals on the guest and host teams.
 First, the **Product Owner** determines what functionality the host team is willing to accept as a contribution.
 The **Contributor** is the individual on the guest team that submits the code contribution for review by the host team.
 The **Trusted Committer** represents the host team in providing any timely support and mentorship that the contributor needs to successfully submit the pull request.
 On small, grass roots efforts a single person often fills _both_ the product owner and trusted committer roles.
 
-With those definitions, here is the basic outline of an inner source contribution.
+With those definitions, here is the basic outline of an InnerSource contribution.
 
 * Guest team or contributor requests a feature from the host team.
 * Product owner ensures that user stories representing the feature request are created, either by members of the guest team or host team.
@@ -37,7 +37,7 @@ They also list any details from the host team on how the feature should be deliv
 Examples of such details include architecture constraints, coding conventions, dependency usages, data contracts, etc.
 * Supported by the trusted committer, the contributor submits the pull request to implement the requested feature.
 
-Note that these steps do not assume a specific system for the general organization of a team's time or priorities. Inner source assumes that teams already have existing methods of organization and provides a framework of how to use them to work together where there is a guest team desiring to contribute code to a host.
+Note that these steps do not assume a specific system for the general organization of a team's time or priorities. InnerSource assumes that teams already have existing methods of organization and provides a framework of how to use them to work together where there is a guest team desiring to contribute code to a host.
 
 This option works well for the guest team because they get the functionality they need when they need it without taking on the long-term burden of maintenance of the solution.
 It works for the host team because they are able to better scale and serve their consumers.

--- a/introduction/04-benefits.md
+++ b/introduction/04-benefits.md
@@ -3,24 +3,24 @@ This accompanying text will appear as a part of the learning path (like [this ex
 
 # What Are the Benefits of InnerSource?
 
-There are many benefits to collaborating via inner source.
-Inner source gives a company a scalable strategy for **guest teams to get feature requests when they need them** without the long-term burden of maintainance.
+There are many benefits to collaborating via InnerSource.
+InnerSource gives a company a scalable strategy for **guest teams to get feature requests when they need them** without the long-term burden of maintainance.
 The company as-a-whole wins as the time of guest teams is put into code that others can use.
 
-While that result is a shining benefit of inner source, there are many benefits to hosts that receive regular inner source contributions.
-Recall that, as part of the inner source process, the product owner on the host team agrees from the outset that contributed features are good and desirable.
-Inner source allows the host team to receive **help in creating a better product** for its consumers!
+While that result is a shining benefit of InnerSource, there are many benefits to hosts that receive regular InnerSource contributions.
+Recall that, as part of the InnerSource process, the product owner on the host team agrees from the outset that contributed features are good and desirable.
+InnerSource allows the host team to receive **help in creating a better product** for its consumers!
 
 **Inner sourcing provides the host team a scalable strategy** for fulfilling the varying amounts of features requested from its many consumers.
 Given the fixed capacity of the full-time members of the host team, it's likely that, at times, the combined business roadmaps of its consumers will require very (or even unreasonably) large amounts of work to be done in the host team's products.
-Without inner source, this situation easily leads to a stressed, overworked team dealing with many feature requests escalated to its leaders.
+Without InnerSource, this situation easily leads to a stressed, overworked team dealing with many feature requests escalated to its leaders.
 
-However, if the host team operates via inner source, the engineering resources required to build those features will appear in-proportion to their importance in the form of guest contributors.
-**Inner source becomes a force multiplier** that allows a host team to temporarily act larger than its actual size during times of high demand.
+However, if the host team operates via InnerSource, the engineering resources required to build those features will appear in-proportion to their importance in the form of guest contributors.
+**InnerSource becomes a force multiplier** that allows a host team to temporarily act larger than its actual size during times of high demand.
 When the demand has ended, the team throughput scales back to normal levels, all without any micromanagement of team headcount or work items.
-Inner source allows engineering time to organically flow where the organization needs it at a given time.
+InnerSource allows engineering time to organically flow where the organization needs it at a given time.
 
-Beyond the raw work that the host team is able to accomplish in its system, regular inner source contributions give the host team **better requirements and prioritization alignment with all of its consumers**.
+Beyond the raw work that the host team is able to accomplish in its system, regular InnerSource contributions give the host team **better requirements and prioritization alignment with all of its consumers**.
 A host team can do its best requirements gathering on the work it produces, but when the consumer itself is the one submitting the work the chances are much higher that the resulting change is aligned to just what the consumer needs.
 While it may be only one single guest team submitting the change, that team is likely representative of many other consumers.
 

--- a/introduction/06-conclusion.md
+++ b/introduction/06-conclusion.md
@@ -3,14 +3,14 @@ This accompanying text will appear as a part of the learning path (like [this ex
 
 # Conclusion
 
-In this learning path, we've given an introduction to inner source.
-Inner source applies open source best practices and principles to internal software development.
+In this learning path, we've given an introduction to the InnerSource approach.
+InnerSource applies open source best practices and principles to internal software development.
 It gives an additional option to consumers when producing teams are not able to deliver a needed feature request.
-Successful inner source involves a **product owner** and **trusted committer** from the **host team** as well as a **contributor** from the **guest team**.
-Done effectively, inner source brings many benefits to both participating teams.
-They key principles upon-which effective inner source works are **voluntary code contribution** and **prioritized mentorship**.
+Successful InnerSource involves a **product owner** and **trusted committer** from the **host team** as well as a **contributor** from the **guest team**.
+Done effectively, InnerSource brings many benefits to both participating teams.
+They key principles upon-which effective InnerSource works are **voluntary code contribution** and **prioritized mentorship**.
 
-While this training contains a high-level overview of inner source, there are many more details useful in making inner source actually work for your team.
-If you want to stay connected to the ongoing conversation around inner source and its best practices, then join [the InnerSource Commons](http://innersourcecommons.org).
-The commons sponsors a Slack channel, an inner source patterns working group, and multiple in-person summits each year.
-Participation in the commons is a great way to stay connected with the latest in inner source.
+While this training contains a high-level overview of InnerSource, there are many more details useful in making InnerSource actually work for your team.
+If you want to stay connected to the ongoing conversation around InnerSource and its best practices, then join [the InnerSource Commons](http://innersourcecommons.org).
+The commons sponsors a Slack channel, an InnerSource patterns working group, and multiple in-person summits each year.
+Participation in the commons is a great way to stay connected with the latest in InnerSource.

--- a/introduction/principles.md
+++ b/introduction/principles.md
@@ -1,12 +1,12 @@
 This file holds the text to accompany the [InnerSource Principles](https://www.safaribooksonline.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321610) video.
 This accompanying text will appear as a part of the learning path (like [this example](https://www.safaribooksonline.com/learning-paths/learning-path-lean/9781491999738/9781491946527-/part01ch01.html)).
 
-# Inner Source Principles
+# InnerSource Principles
 
 Every company, team, project, and individual is different.
-Because of that fact, the exact way that the concept of inner source works will vary from one situation to another.
-At its core, however, are four principles that form the bedrock of any successful instance of inner source.
-These principles have inspiration in successful open source projects and must be respected and present in order for inner source to achieve the benefits described earlier.
+Because of that fact, the exact way that the concept of InnerSource works will vary from one situation to another.
+At its core, however, are four principles that form the bedrock of any successful instance of InnerSource.
+These principles have inspiration in successful open source projects and must be respected and present in order for InnerSource to achieve the benefits described earlier.
 
 The principles are:
 * **Openness**
@@ -22,10 +22,10 @@ In being open, a project is set up in such a way that contributing is as frictio
 Projects should be discoverable and well documented.
 Anyone within an organization should be able to find them and ramp up without an inordinate amount of direct guidance from host team members.
 Host team contact information should be prevalent with as many channels as makes sense for the project.
-Host team intentions to inner source their project should be broadcast through relevant organization channels.
+Host team intentions to use the InnerSource approach in their project should be broadcast through relevant organization channels.
 
 By no means is the above an exhaustive list. Project openness will typically be directly related to how successful a project is
-in terms of inner sourcing: The more open it is, the less barriers are put in place for prospective contributors. The less open
+in terms of their application of the InnerSource approach: The more open it is, the less barriers are put in place for prospective contributors. The less open
 it is, the more difficult it becomes for anyone to contribute.
 
 ## Transparency
@@ -42,7 +42,7 @@ When possible, the above should be communicated clearly and in details, from tea
 
 ## Prioritized Mentorship
 
-_Mentorship_ from host team to guest team via trusted committers is a key aspect of inner source.
+_Mentorship_ from host team to guest team via trusted committers is a key aspect of InnerSource.
 Contributors on guest teams are upleveled so that they understand enough about the host team system to change it successfully.
 In the process of doing so, they come to better understand the host team's software system as a general consumer.
 They can use it more effectively and help other consumers to do so as well.
@@ -57,7 +57,7 @@ Open source readily recognizes this point and considers it as an honor to achiev
 
 ## Voluntary Code Contribution
 
-The first word _Voluntary_ means that engagement in inner source from both the guest and host teams occurs of their own free will.
+The first word _Voluntary_ means that engagement in InnerSource from both the guest and host teams occurs of their own free will.
 The guest team voluntarily donates code to the host team and the host team voluntarily accepts it.
 This opt-in nature means that each team needs to be certain that their involvement adds value to the others' objectives.
 Never is a host team required to accept a contribution that isn't in ultimate alignment with their overall mission.


### PR DESCRIPTION
Modified the introduction articles according to #39's decision to use InnerSource instead of 'inner source' where possible. 
I had to modify the sentence in a few cases but many other cases worked in a search&replace for my sense of writing. 

@rrrutledge, @arnom-ms and @NewMexicoKid : I'd be happy if you could provide me with your take on the language and see if I have overseen any instance of the word.