### PR TITLE
Initial move of TC workbook from GoogleDoc to GitHub

### DIFF
--- a/workbook/02-trusted-committer.asciidoc
+++ b/workbook/02-trusted-committer.asciidoc
@@ -1,0 +1,336 @@
+Video:  The Trusted Committer Role in InnerSource
+
+SEGMENT: Introduction
+
+Question 1. What sentence best describes the motivation for the name “Trusted Committer”?
+
+They are the only ones that are trusted to make commits to the project.
+They are trusted to keep the software and the community that is developing it healthy.
+It is the role name used by Apache and GitHub.
+They are trusted by the product owner to commit the most important features.
+
+Correct answer: 2
+
+Why 1 is incorrect: A good InnerSource project has a community of people submitting commits to the project. The trusted nature of the trusted committer goes beyond just raw coding activity.
+
+Why 2 is correct: The role of the trusted committer is broad and encompasses subtle human interactions. After being chosen for their technical and interpersonal skills, the trusted committers employ a wide range of practices to elicit contributions, build the confidence and skills of the contributors, and ensure positive interactions throughout the community. There are no specifications for such work. It involves trust by the community and product owners.
+
+Why 3 is incorrect: Apache and GitHub have different names for roles that encompass some of the responsibilities of the trusted committer, but not the full set.  The role name of “trusted committer” is intentionally unique to InnerSource.
+
+Why 4 is incorrect: Product Owners don’t play favorites as to who implements stories for the community.
+
+
+SEGMENT: Ensuring Product Quality
+
+NOTE:
+More than one answer may be correct in some questions.
+
+Question 1. Which of the following is a responsibility of a trusted committer?
+
+Ensuring that a contribution reflects end-user needs
+Ensuring high code quality in their own submissions and those of other contributors
+Defending the community’s coding and participation standards
+Documenting these standards
+
+Correct answers: 2, 3, and 4
+
+Why 1 is incorrect: A contributor usually decides to join a project in order to ensure that the code meets a perceived end-user need. Thus, it is the contributors (or their managers) who are responsible for determining end-user needs, and the trusted committer assumes that any contribution is done for a good reason.
+
+Why 2 is correct: Whatever benefits InnerSource offers to contributors and their community, it ultimately must produce top-quality applications in order to be viable. That is the ultimate goal of the process.
+
+Why 3 is correct: Code will be buggy and hard to maintain if contributors fail to follow standards in style and quality. The trusted committer ensures that they do.
+
+Why 4 is correct: Potential contributors have the right to view explicit standards before they try to submit contributions. Documentation is key, and trusted committers should either write the documentation or recruit other knowledgeable people to do so.
+
+Question 2. Management tasks of the trusted committer include:
+
+Track release dates and recommend changes to these dates when needed
+Scheduling the time of other contributors
+Recruiting outside contributors
+Recommending promotions for contributors
+
+Correct answers: 1 and 3
+
+Why 1 is correct: The trusted committers know best what state the code is in, how robust it is, and how far they have come to meeting user requirements. Thus, they can recognize earlier than anyone else when a release date is unreasonable. It is their responsibility to communicate the need for a shift to management.
+
+Why 2 is incorrect: Contributors from outside the host team are volunteers, and join a project because they have their own motivations for seeing projects get done. Neither the outside contributors or their managers will tolerate being told how to spend their time.
+
+Why 3 is correct: Although InnerSource is often driven by outsiders who bang on the doors of a host team to be let in, the team can also benefit from reaching out and finding outsiders who can help. The trusted committer can explain to potential contributors how they and their teams could benefit by participating.
+
+Why 4 is incorrect: Promotions, like other personnel matters, are still handled by team managers when InnerSource is in place. InnerSource is about building a productive community and educating its members, not formal rewards. A trusted committer may inform a contributor’s manager about the value and expertise shown by the contributor, but recommending rewards remains outside the trusted committer’s role.
+
+Question 3. Ideally, contributors view trusted committers as:
+
+Models for their own behavior
+A layer of the management structure for approving code changes
+Sources of information about how to write successful contributions
+Expert coders who implement the contributors’ suggestions
+
+Correct answers: 1 and 3
+
+Why 1 is correct: Trusted committers should embody all the traits of a good community member, both in their coding skills and in their interactions. Therefore, contributors are likely emulate the trusted committers’ behavior and hopefully to become trusted committers themselves.
+
+Why 2 is incorrect: InnerSource, done properly, puts responsibility on the contributors for deciding what code needs to change and how to change it. Trusted committers can make sure that the code follows style guidelines and doesn’t break anything else. However, the trusted committer is not part of management. InnerSource reduces the need for managers to direct projects at a detailed level.
+
+Why 3 is correct: A contributor wants to get their code or other contributions into the host team’s code base; the trusted committer is someone who has done that and can explain how.
+
+Why 4 is incorrect: Contributors take responsibility for code in InnerSource. Trusted committers must resist the temptation to tidy up the contributors’ work. Trusted committers can offer advice, but the contributor implements the ideas.
+
+Question 4. How do trusted committers maintain product quality?
+
+Reviewing pull requests.
+Documenting community standards.
+Ensuring that community decisions are of high quality.
+Writing code as part of each contribution.
+
+Correct answers: 1, 2, and 3
+
+Why 1 is correct: A pull request gives a contributor his or her personal sandbox to work in; the contributor then offers the results to the host team. The resulting contribution may require several iterations to reach the necessary quality, and getting there requires feedback from trusted committers.
+
+Why 2 is correct: Documentation helps all contributors agree on what to do. It’s useful for contributors to read the documentation before starting their contributions, and for trusted committers to point to this documentation when requesting changes to a contribution.
+
+Why 3 is correct: Communication and interaction takes on a greater importance in InnerSource. Contributors have opinions about what code should do and how to make it work, so the trusted committer helps communities reach decisions that meet all needs.
+
+Why 4 is incorrect: The healthiest projects have many people working independently. If contributors can take full responsibility for their code, they learn more and can make more contributions. As much as possible, trusted committers avoid handling contributions for which other contributors have taken responsibility.
+
+SEGMENT: Keeping the Community Healthy
+
+NOTE:
+More than one answer may be correct in some questions.
+
+Question 1. Which of the following are part of the trusted committer's responsibilities?
+
+Making participation fun and engaging
+Telling contributors what to work on next
+Reining in difficult or disruptive members of the community
+Making a contributor feel good just for making a submission
+
+Correct answers: 1, 3, and 4
+
+Why 1 is correct: A positive atmosphere brings in more contributions than one that is tense or demeaning. In fact, tense and demeaning projects tend to fall apart. And in any case, a team owes its contributors an uplifting and affirming experience. Trusted committers are the first line of defense against negativity, although management should also create a top-down culture of support.
+
+Why 2 is incorrect: Contributors must have their own motivations to change code. They are not employees of the trusted committer. The trusted committer can suggest that a contributor work on a particular change request or bug, either because the project needs the help or because the task would be a good learning experience, but the contributor makes the final decision.
+
+Why 3 is correct: People may temporarily, or because of their disposition, hurt others psychologically. A single negative interaction can seriously damage a whole community. Trusted committers have learned how to create a positive atmosphere, and they must intervene quickly to halt run-away negative exchanges and explicitly guide others about how to behave.
+
+Why 4 is correct: Some contributors lack the skills to make code of the quality required by a team, or may be constrained by other factors such as time. But InnerSource thrives because of outside contributors, so everyone should be encouraged to try. Encouragement motivates a contributor to listen to advice and try again until the contribution works.
+
+Question 2. Among the factors that motivate contributors to participate are:
+
+A respectful and pleasant community
+Chances to learn and improve skills
+More open planning process
+Quicker implementation of features needed by their teams
+
+Correct answers: 1, 2, 3, and 4
+
+Why 1 is correct: Nobody wants to be in an unpleasant group of people. A good community attracts those who can make successful contributions.
+
+Why 2 is correct: Formal training has limited value until the learner tries to apply the skills in real life. A contribution to another project is an excellent way to learn from experience and provide extra dimensions to training.
+
+Why 3 is correct: At least in the conventional view of organizational planning, the knotty questions of feature sets and priorities emerge from high-level managerial meetings. Under InnerSource, a team or even an individual can decide that something needs to get done and then implement it, with guidance from a trusted committer. People end up working on important things because they want to, and the priorities emerge from open, documented discussions.
+
+Why 4 is correct: Instead of waiting for another team to implement a needed feature, contributors can study the code and write up the feature when their own team needs it.This is not done in isolation, but in discussion and collaboration with the host team.
+
+Question 3. How does a trusted committer keep the community healthy?
+
+Stay out of the contributors’ way.
+Laud first-time and excellent contributions.
+Prioritize onboarding and mentorship over milestones.
+When offering corrections, explain the theory behind the suggested change.
+
+Correct answers: 2, 3, 4
+
+Why 1 is incorrect: Steady facilitation and mentoring from the trusted committer to contributors actually improves community health.
+
+Why 2 is correct: Transparency is one of the virtues of InnerSource. When people contribute, both the community and the organization’s managers should know about it.
+
+Why 3 is correct: Trusted committers think long-term. Although getting each feature done is important, they know that recruitment and training will pay off in years to come with more contributions. Thus, the trusted committer may put in time recruiting or mentoring a contributor for some small contributions, perhaps more time than the individual contribution is worth. Being mentored and treated respectfully increases the likelihood that the contributor will come back for more.
+
+Why 4 is correct: Although review is a key task to preserve the quality of the code base, the trusted committer is thinking long-term during the task. The trusted committer wants the contributor to learn from this experience and apply the lessons to future contributions.
+
+SEGMENT:  Uplevelling Community Members
+
+NOTE:
+More than one answer may be correct in some questions.
+
+Question 1. Trusted committers build community in many ways, including by:
+
+Setting new goals for the community at regular intervals
+Letting outsiders know about the community and what it offers
+Encouraging contributors to take on bigger tasks
+Encouraging members to ignore disruptive comments
+
+Correct answers: 2 and 3
+
+Why 1 is incorrect: Goals are set by management. Trusted committers facilitate the work done by others, but do not set the goals.
+
+Why 2 is correct: Many staff fail to appreciate the goals and benefits of InnerSource, particularly when they have not been exposed to its ideas before. Trusted committers are evangelists for InnerSource in general and for their teams in particular. They go so far as to hold special meetings or lunchtime sessions to play up their InnerSource efforts.
+
+Why 3 is correct: We want every person to grow in the job. Contributors usually start small, but are capable of bigger contributions. Trusted committers can encourage them to take on higher-impact work as they go along, and mentor them so that they succeed at that work. The end result is a code base with broader applicability, higher quality, and potentially more features.
+
+Why 4 is incorrect: A disruptive person can be very damaging to the community. Comments that are hostile, demeaning, or even simply distracting should not be tolerated. The trusted committer does not ignore a disruptive comment or tell others to do so. He or she announces to the community that the comment is inappropriate, and then engages in a constructive manner with the disruptive person to ensure no such behavior happens again.
+
+Question 2. Why is it important for a trusted committer to uplevel community members?
+
+It’s not important - the community will do what it needs in order to get its work done.
+Upleveled community members can begin to help each other, enabling a larger community.
+A community composed of more mature members will produce better software.
+Upleveled individuals can augment the host team’s ability to deliver its roadmap.
+
+Correct answers: 2, 3, and 4
+
+Why 1 is incorrect: A community does not form spontaneously, even though the need for it is there.  A key part of the trusted committer role is supplying the social connection and encouragement for the community and the members in it to work together..
+
+Why 2 is correct: As people gain both skills and confidence, they can offer these skills to others. Contributors can start to act like trusted committers in preserving community standards and educating other members.
+
+Why 3 is correct: One of the crucial purposes of mentoring is to enable each contributor to do better each time, and take on a bigger scope in the project.
+
+Why 4 is correct: As contributors become more sophisticated, their productivity increases and their contributions become more significant. Furthermore, they can help set goals that improve the overall health of the project.
+SEGMENT: Lowering the Barriers to Entry
+
+NOTE:
+More than one answer may be correct in some questions.
+
+Question 1. Contributors may be hindered from working on InnerSource projects by:
+
+Being too busy with their day job to contribute
+A lack of consideration for their InnerSource contributions during employee reviews
+Difficulty building and testing the software in the contributor’s own environment
+The use of a contributor’s code by other teams
+
+Correct answers: 1, 2, and 3
+
+Why 1 is correct: Developers generally have a full plate getting done what their managers assign them. The promise held out by InnerSource is that adding features that your project needs to another team’s project can improve the productivity of your own team, as well as the code of the team to which you are contributing. The open communication fostered by InnerSource also pays off for both teams over time. A contributor may need to persuade their management that the work on another team’s code base will help the contributor’s team and the company achieve its goals faster and more efficiently.
+
+Why 2 is correct: Every effort that benefits a company should be recognized and explicitly rewarded; this encourages employees to take on important new tasks. At the beginning InnerSource is not embedded in a company’s fundamental understanding of its tasks, so managers will not recognize the contributions that their employees make to other projects. Until InnerSource is understood and appreciated by management, employees will find it hard to participate.
+
+Why 3 is correct: Each team may use different tools and repositories. A repository shared across teams makes it much easier to work on the shared code. Related processes, such as handling release builds, bug reports, change requests, and testing, should be designed so people from other teams can work in ways they find familiar. Adding helpful documents such as a CONTRIBUTING.md file explaining the communities’ local customs and describing the way to set up the software in the contributor’s own environment can help to make people from other teams feel at home faster and is much recommended. 
+
+Why 4 is incorrect: One of the great benefits of InnerSource is the ability of all teams to use the features designed and coded by other teams. Companies adopt InnerSource largely in order to maximize the value of each code contribution by giving access to the code to every relevant user.
+.
+Question 2. Guidelines for contributing can be conveyed through:
+
+The README file
+The CONTRIBUTING file
+Describing the contribution process in step-by-step fashion 
+Answering questions from potential contributors
+
+Correct answers: 1, 2, 3, and 4
+
+Why 1 and 2 are correct; Both of these files should be read by contributors before they start participation, and both are good places for team guidelines.
+
+Why 3 is correct: Step-by-step procedures, where they can be defined, help turn the abstract into the concrete. It’s easier to follow a clear procedure than to apply general principles.
+
+Why 4 is correct: The trusted committer offers personal guidance to contributors. It’s useful to preserve such interactions in written form somewhere where other contributors can read and hopefully learn from them.
+SEGMENT: Advocating for the Community's Needs
+
+NOTE:
+More than one answer may be correct in some questions.
+
+Question 1. Trusted committers need to be advocates for their community within the larger organization in order to:
+
+Make sure that a contributor's work is directly relevant to his own team's goals
+Get recognition for contributors
+Show potential contributors and their managers why it benefits them to contribute
+Encourage contributors to take on more responsibility
+
+Correct answers: 2, 3, and 4
+
+Why 1 is incorrect: Contributors work on another team’s code in order to meet the needs of the contributor’s team. The contribution should not break anything, of course, so it should not be in direct contradiction to the goals of the trusted committer’s team. But the relevance applies to the contributor’s team, not the trusted committer’s team.
+
+Why 2 is correct: Recognition is both personally satisfying and potentially a step toward formal rewards such as bonuses and promotions. Tools such as version control and bug report databases contain historical records of contributions, but trusted committers should also recognize key contributions in the project’s communication channels.
+
+Why 3 and 4 are correct: Contributors are more likely to invest time and effort when they see that the project benefits them and is appreciated throughout the organization.
+
+
+SEGMENT: Becoming a Trusted Committer
+
+NOTE:
+More than one answer may be correct in some questions.
+
+Question 1. If you become a trusted committer, you should expect to:
+
+Work with a narrow range of contributions
+Spend more time coding
+Handle stressful situations on a project
+Allow the community to scrutinize your behavior
+
+Correct answers: 3 and 4
+
+Why 1 is incorrect: Trusted committers tend to expand the scope of their work, not narrow the scope. As a trusted committer, you will work with a variety of people from different teams.
+
+Why 2 is incorrect: Time has to come from somewhere. Trusted committers will have to give up some coding time in order to check other contributors’ code, mentor the contributors, and carry out planning. However, trusted committers should do some coding in order to keep up their own skills and maintain their knowledge of their team’s code base. Some people adopt the trusted committer role for limited periods of time, and return to full-time coding.
+
+Why 3 is correct: A trusted committer takes personal responsibility for the health of the community, and all communities experience stress. Such stress can come from personal disagreements, clashing priorities, constraints on time and resources, or many other sources. The trusted committer must keep calm and deal with these problems.
+
+Why 4 is correct: A trusted committer is not just a technical expert but a role model for behavior. Thus, you should be transparent in your behavior and willing to receive feedback from project participants.
+
+Question 2. Meritocracy in InnerSource, among other things, calls for:
+
+Recognizing the value of trusted committers as communicators
+Restricting each team to just a few trusted committers
+Keeping the best programmers on coding tasks instead of making them trusted committers
+Meeting all the deadlines set by management
+
+Correct answer: 1
+
+Why 1 is correct: Many technical projects place great value on technical skills--which are certainly necessary--but undervalue what they dismissively call “soft” skills such as communication, problem-solving, and training. InnerSource is a community, and communities require these additional skills. A trusted committer is chosen and recognized for the full range of skills necessary to induce contributions.
+
+Why 2 is incorrect: InnerSource thrives when many people share roles. Healthy teams encourage many qualified developers to become trusted committers. People can also move in and out of the trusted committer role, sharing it with other team members. This improves everyone’s skills.
+
+Why 3 is incorrect: Because trusted committers vet other contributors code and mentor the contributors, managers should want their best developers to become trusted committers at least part of the time.
+
+Why 4 is incorrect: InnerSource focuses on quality code and community-building, not deadlines. InnerSource can sometimes help a team meet its deadlines, because the team can recruit people temporarily from other teams on critical tasks. However, at other times, trusted committers request extensions to deadlines in order to ensure quality.
+
+Question 3.  Which are primary attributes of a good candidate for trusted committer?
+
+Already made successful contributions to the project.
+Is on the host team for the project.
+Actively helps others in the community with questions.
+Participates in conversations on project roadmap and management.
+
+Correct answers: 1, 3, 4
+
+Why 1 is correct: One of the primary responsibilities of a trusted committer is to help others to contribute successfully to the project.  A trusted committer must have a history of doing so themselves in order to be qualified to help others to do the same.
+
+Why 2 is incorrect: This was never cited as a requirement. Although the host team will probably provide  trusted committers when the project is first offered to the InnerSource community, it can recruit trusted committers from other teams that care intensely about the project. Regardless of the team that employs the trusted committers, they should arrange the time and resources to participate with their managers, and should act as representatives of the project to the larger community and the organization as a whole.
+
+Why 3 is correct: A large part of a trusted committer’s responsibilities involves social support to contributors. A good candidate will have already exhibited some of this social behavior even before official designation as trusted committer.
+
+Why 4 is correct: The trust placed in a trusted committer extends beyond purely technical considerations. Trusted committers also communicate with the product owner and management.  Interest in these areas indicates someone that may be a good trusted committer.
+
+Question 4: What are some benefits of becoming a trusted committer?
+
+Taking on additional responsibility in a project prepares you for expanded leadership in the company.
+Being in a position of teaching others helps you to understand the project and code better yourself.
+You can expect an increase in monetary compensation at the time of assuming the responsibilities of Trusted Committer.
+Your impact on the project expands as you help to shepherd and guide more contributions than you’d have time to write yourself.
+
+Correct answers: 1, 2, 4
+
+Why 1 is correct: Acting as a trusted committer is a great stretch role to build the same leadership skills that will be required if you decide to pursue a full-time leadership role later on. 
+
+Why 2 is correct: In all areas, teaching something to others requires that you know it better yourself.  This holds true in being a trusted committer.  Teaching others will give you added mastery over the project and code you are working on.
+
+Why 3 is incorrect: It is not common that an immediate monetary increase is directly tied to the role of trusted committer.  However, the skills required to become a trusted committer and those that are developed by being one tend to be highly valuable to companies.  Because of that, becoming a trusted committer tends to be a good career move in building the skills that make you a more valuable leader.
+
+Why 4 is correct: Being a trusted committer is a force multiplier on your impact within the project.  As you mentor and uplevel contributors, each of their contributions will carry your mark and influence with them.  This effect results in your improving and adding to the project many times faster than you could just by heads-down coding on your own.
+
+Question 5: Which of the following describes the mechanics of becoming a trusted committer?
+
+Company management moves the person that they want to be leading the project into the role.
+The community or its leadership nominates new trusted committers.
+Anyone who is interested volunteers.
+The project founder assumes the role.
+
+Correct answers: 2 and 4.
+
+Why 1 is incorrect:  The principle of meritocracy teaches Trusted Committership is earned, not assigned.  It’s also the case that the Trusted Committer should voluntarily accept an invitation to serve rather than being conscripted into the role.
+
+Why 2 is correct:  The community is in the best position to evaluate which of its members have demonstrated the interest and aptitudes to serve as Trusted Committer.
+
+Why 3 is incorrect: Interest alone isn’t the only prerequisite for Trusted Committership.  The principle of meritocracy teaches Trusted Committership is earned through demonstrated positive activity in the community.
+
+Why 4 is correct:  At the outset with no community and no history, the project founder often assumes the role of Trusted Committer to build up an initial community.  This person in addition to building up the project also builds up new potential Trusted Committers as they interact with community members.
+

--- a/workbook/02-trusted-committer.asciidoc
+++ b/workbook/02-trusted-committer.asciidoc
@@ -1,15 +1,15 @@
-Video:  The Trusted Committer Role in InnerSource
+== Video:  The Trusted Committer Role in InnerSource
 
-SEGMENT: Introduction
+=== SEGMENT: Introduction
 
-Question 1. What sentence best describes the motivation for the name “Trusted Committer”?
+==== Question 1. What sentence best describes the motivation for the name “Trusted Committer”?
 
-They are the only ones that are trusted to make commits to the project.
-They are trusted to keep the software and the community that is developing it healthy.
-It is the role name used by Apache and GitHub.
-They are trusted by the product owner to commit the most important features.
+. They are the only ones that are trusted to make commits to the project.
+. They are trusted to keep the software and the community that is developing it healthy.
+. It is the role name used by Apache and GitHub.
+. They are trusted by the product owner to commit the most important features.
 
-Correct answer: 2
+===== Question: 2
 
 Why 1 is incorrect: A good InnerSource project has a community of people submitting commits to the project. The trusted nature of the trusted committer goes beyond just raw coding activity.
 
@@ -20,19 +20,19 @@ Why 3 is incorrect: Apache and GitHub have different names for roles that encomp
 Why 4 is incorrect: Product Owners don’t play favorites as to who implements stories for the community.
 
 
-SEGMENT: Ensuring Product Quality
+=== SEGMENT: Ensuring Product Quality
 
-NOTE:
+TIP:
 More than one answer may be correct in some questions.
 
-Question 1. Which of the following is a responsibility of a trusted committer?
+==== Question 1. Which of the following is a responsibility of a trusted committer?
 
-Ensuring that a contribution reflects end-user needs
-Ensuring high code quality in their own submissions and those of other contributors
-Defending the community’s coding and participation standards
-Documenting these standards
+. Ensuring that a contribution reflects end-user needs
+. Ensuring high code quality in their own submissions and those of other contributors
+. Defending the community’s coding and participation standards
+. Documenting these standards
 
-Correct answers: 2, 3, and 4
+===== Correct answers: 2, 3, and 4
 
 Why 1 is incorrect: A contributor usually decides to join a project in order to ensure that the code meets a perceived end-user need. Thus, it is the contributors (or their managers) who are responsible for determining end-user needs, and the trusted committer assumes that any contribution is done for a good reason.
 
@@ -42,14 +42,14 @@ Why 3 is correct: Code will be buggy and hard to maintain if contributors fail t
 
 Why 4 is correct: Potential contributors have the right to view explicit standards before they try to submit contributions. Documentation is key, and trusted committers should either write the documentation or recruit other knowledgeable people to do so.
 
-Question 2. Management tasks of the trusted committer include:
+==== Question 2. Management tasks of the trusted committer include:
 
-Track release dates and recommend changes to these dates when needed
-Scheduling the time of other contributors
-Recruiting outside contributors
-Recommending promotions for contributors
+. Track release dates and recommend changes to these dates when needed
+. Scheduling the time of other contributors
+. Recruiting outside contributors
+. Recommending promotions for contributors
 
-Correct answers: 1 and 3
+===== Correct answers: 1 and 3
 
 Why 1 is correct: The trusted committers know best what state the code is in, how robust it is, and how far they have come to meeting user requirements. Thus, they can recognize earlier than anyone else when a release date is unreasonable. It is their responsibility to communicate the need for a shift to management.
 
@@ -59,14 +59,14 @@ Why 3 is correct: Although InnerSource is often driven by outsiders who bang on 
 
 Why 4 is incorrect: Promotions, like other personnel matters, are still handled by team managers when InnerSource is in place. InnerSource is about building a productive community and educating its members, not formal rewards. A trusted committer may inform a contributor’s manager about the value and expertise shown by the contributor, but recommending rewards remains outside the trusted committer’s role.
 
-Question 3. Ideally, contributors view trusted committers as:
+==== Question 3. Ideally, contributors view trusted committers as:
 
-Models for their own behavior
-A layer of the management structure for approving code changes
-Sources of information about how to write successful contributions
-Expert coders who implement the contributors’ suggestions
+. Models for their own behavior
+. A layer of the management structure for approving code changes
+. Sources of information about how to write successful contributions
+. Expert coders who implement the contributors’ suggestions
 
-Correct answers: 1 and 3
+===== Correct answers: 1 and 3
 
 Why 1 is correct: Trusted committers should embody all the traits of a good community member, both in their coding skills and in their interactions. Therefore, contributors are likely emulate the trusted committers’ behavior and hopefully to become trusted committers themselves.
 
@@ -76,14 +76,14 @@ Why 3 is correct: A contributor wants to get their code or other contributions i
 
 Why 4 is incorrect: Contributors take responsibility for code in InnerSource. Trusted committers must resist the temptation to tidy up the contributors’ work. Trusted committers can offer advice, but the contributor implements the ideas.
 
-Question 4. How do trusted committers maintain product quality?
+==== Question 4. How do trusted committers maintain product quality?
 
-Reviewing pull requests.
-Documenting community standards.
-Ensuring that community decisions are of high quality.
-Writing code as part of each contribution.
+. Reviewing pull requests.
+. Documenting community standards.
+. Ensuring that community decisions are of high quality.
+. Writing code as part of each contribution.
 
-Correct answers: 1, 2, and 3
+===== Correct answers: 1, 2, and 3
 
 Why 1 is correct: A pull request gives a contributor his or her personal sandbox to work in; the contributor then offers the results to the host team. The resulting contribution may require several iterations to reach the necessary quality, and getting there requires feedback from trusted committers.
 
@@ -93,19 +93,19 @@ Why 3 is correct: Communication and interaction takes on a greater importance in
 
 Why 4 is incorrect: The healthiest projects have many people working independently. If contributors can take full responsibility for their code, they learn more and can make more contributions. As much as possible, trusted committers avoid handling contributions for which other contributors have taken responsibility.
 
-SEGMENT: Keeping the Community Healthy
+=== SEGMENT: Keeping the Community Healthy
 
-NOTE:
+TIP:
 More than one answer may be correct in some questions.
 
-Question 1. Which of the following are part of the trusted committer's responsibilities?
+==== Question 1. Which of the following are part of the trusted committer's responsibilities?
 
-Making participation fun and engaging
-Telling contributors what to work on next
-Reining in difficult or disruptive members of the community
-Making a contributor feel good just for making a submission
+. Making participation fun and engaging
+. Telling contributors what to work on next
+. Reining in difficult or disruptive members of the community
+. Making a contributor feel good just for making a submission
 
-Correct answers: 1, 3, and 4
+===== Correct answers: 1, 3, and 4
 
 Why 1 is correct: A positive atmosphere brings in more contributions than one that is tense or demeaning. In fact, tense and demeaning projects tend to fall apart. And in any case, a team owes its contributors an uplifting and affirming experience. Trusted committers are the first line of defense against negativity, although management should also create a top-down culture of support.
 
@@ -115,14 +115,14 @@ Why 3 is correct: People may temporarily, or because of their disposition, hurt 
 
 Why 4 is correct: Some contributors lack the skills to make code of the quality required by a team, or may be constrained by other factors such as time. But InnerSource thrives because of outside contributors, so everyone should be encouraged to try. Encouragement motivates a contributor to listen to advice and try again until the contribution works.
 
-Question 2. Among the factors that motivate contributors to participate are:
+==== Question 2. Among the factors that motivate contributors to participate are:
 
-A respectful and pleasant community
-Chances to learn and improve skills
-More open planning process
-Quicker implementation of features needed by their teams
+. A respectful and pleasant community
+. Chances to learn and improve skills
+. More open planning process
+. Quicker implementation of features needed by their teams
 
-Correct answers: 1, 2, 3, and 4
+===== Correct answers: 1, 2, 3, and 4
 
 Why 1 is correct: Nobody wants to be in an unpleasant group of people. A good community attracts those who can make successful contributions.
 
@@ -132,14 +132,14 @@ Why 3 is correct: At least in the conventional view of organizational planning, 
 
 Why 4 is correct: Instead of waiting for another team to implement a needed feature, contributors can study the code and write up the feature when their own team needs it.This is not done in isolation, but in discussion and collaboration with the host team.
 
-Question 3. How does a trusted committer keep the community healthy?
+==== Question 3. How does a trusted committer keep the community healthy?
 
-Stay out of the contributors’ way.
-Laud first-time and excellent contributions.
-Prioritize onboarding and mentorship over milestones.
-When offering corrections, explain the theory behind the suggested change.
+. Stay out of the contributors’ way.
+. Laud first-time and excellent contributions.
+. Prioritize onboarding and mentorship over milestones.
+. When offering corrections, explain the theory behind the suggested change.
 
-Correct answers: 2, 3, 4
+===== Correct answers: 2, 3, 4
 
 Why 1 is incorrect: Steady facilitation and mentoring from the trusted committer to contributors actually improves community health.
 
@@ -149,19 +149,19 @@ Why 3 is correct: Trusted committers think long-term. Although getting each feat
 
 Why 4 is correct: Although review is a key task to preserve the quality of the code base, the trusted committer is thinking long-term during the task. The trusted committer wants the contributor to learn from this experience and apply the lessons to future contributions.
 
-SEGMENT:  Uplevelling Community Members
+=== SEGMENT:  Uplevelling Community Members
 
-NOTE:
+TIP:
 More than one answer may be correct in some questions.
 
-Question 1. Trusted committers build community in many ways, including by:
+==== Question 1. Trusted committers build community in many ways, including by:
 
-Setting new goals for the community at regular intervals
-Letting outsiders know about the community and what it offers
-Encouraging contributors to take on bigger tasks
-Encouraging members to ignore disruptive comments
+. Setting new goals for the community at regular intervals
+. Letting outsiders know about the community and what it offers
+. Encouraging contributors to take on bigger tasks
+. Encouraging members to ignore disruptive comments
 
-Correct answers: 2 and 3
+===== Correct answers: 2 and 3
 
 Why 1 is incorrect: Goals are set by management. Trusted committers facilitate the work done by others, but do not set the goals.
 
@@ -171,14 +171,14 @@ Why 3 is correct: We want every person to grow in the job. Contributors usually 
 
 Why 4 is incorrect: A disruptive person can be very damaging to the community. Comments that are hostile, demeaning, or even simply distracting should not be tolerated. The trusted committer does not ignore a disruptive comment or tell others to do so. He or she announces to the community that the comment is inappropriate, and then engages in a constructive manner with the disruptive person to ensure no such behavior happens again.
 
-Question 2. Why is it important for a trusted committer to uplevel community members?
+==== Question 2. Why is it important for a trusted committer to uplevel community members?
 
-It’s not important - the community will do what it needs in order to get its work done.
-Upleveled community members can begin to help each other, enabling a larger community.
-A community composed of more mature members will produce better software.
-Upleveled individuals can augment the host team’s ability to deliver its roadmap.
+. It’s not important - the community will do what it needs in order to get its work done.
+. Upleveled community members can begin to help each other, enabling a larger community.
+. A community composed of more mature members will produce better software.
+. Upleveled individuals can augment the host team’s ability to deliver its roadmap.
 
-Correct answers: 2, 3, and 4
+===== Correct answers: 2, 3, and 4
 
 Why 1 is incorrect: A community does not form spontaneously, even though the need for it is there.  A key part of the trusted committer role is supplying the social connection and encouragement for the community and the members in it to work together..
 
@@ -187,19 +187,19 @@ Why 2 is correct: As people gain both skills and confidence, they can offer thes
 Why 3 is correct: One of the crucial purposes of mentoring is to enable each contributor to do better each time, and take on a bigger scope in the project.
 
 Why 4 is correct: As contributors become more sophisticated, their productivity increases and their contributions become more significant. Furthermore, they can help set goals that improve the overall health of the project.
-SEGMENT: Lowering the Barriers to Entry
+=== SEGMENT: Lowering the Barriers to Entry
 
-NOTE:
+TIP:
 More than one answer may be correct in some questions.
 
-Question 1. Contributors may be hindered from working on InnerSource projects by:
+==== Question 1. Contributors may be hindered from working on InnerSource projects by:
 
-Being too busy with their day job to contribute
-A lack of consideration for their InnerSource contributions during employee reviews
-Difficulty building and testing the software in the contributor’s own environment
-The use of a contributor’s code by other teams
+. Being too busy with their day job to contribute
+. A lack of consideration for their InnerSource contributions during employee reviews
+. Difficulty building and testing the software in the contributor’s own environment
+. The use of a contributor’s code by other teams
 
-Correct answers: 1, 2, and 3
+===== Correct answers: 1, 2, and 3
 
 Why 1 is correct: Developers generally have a full plate getting done what their managers assign them. The promise held out by InnerSource is that adding features that your project needs to another team’s project can improve the productivity of your own team, as well as the code of the team to which you are contributing. The open communication fostered by InnerSource also pays off for both teams over time. A contributor may need to persuade their management that the work on another team’s code base will help the contributor’s team and the company achieve its goals faster and more efficiently.
 
@@ -209,33 +209,33 @@ Why 3 is correct: Each team may use different tools and repositories. A reposito
 
 Why 4 is incorrect: One of the great benefits of InnerSource is the ability of all teams to use the features designed and coded by other teams. Companies adopt InnerSource largely in order to maximize the value of each code contribution by giving access to the code to every relevant user.
 .
-Question 2. Guidelines for contributing can be conveyed through:
+==== Question 2. Guidelines for contributing can be conveyed through:
 
-The README file
-The CONTRIBUTING file
-Describing the contribution process in step-by-step fashion 
-Answering questions from potential contributors
+. The README file
+. The CONTRIBUTING file
+. Describing the contribution process in step-by-step fashion 
+. Answering questions from potential contributors
 
-Correct answers: 1, 2, 3, and 4
+===== Correct answers: 1, 2, 3, and 4
 
 Why 1 and 2 are correct; Both of these files should be read by contributors before they start participation, and both are good places for team guidelines.
 
 Why 3 is correct: Step-by-step procedures, where they can be defined, help turn the abstract into the concrete. It’s easier to follow a clear procedure than to apply general principles.
 
 Why 4 is correct: The trusted committer offers personal guidance to contributors. It’s useful to preserve such interactions in written form somewhere where other contributors can read and hopefully learn from them.
-SEGMENT: Advocating for the Community's Needs
+=== SEGMENT: Advocating for the Community's Needs
 
-NOTE:
+TIP:
 More than one answer may be correct in some questions.
 
-Question 1. Trusted committers need to be advocates for their community within the larger organization in order to:
+==== Question 1. Trusted committers need to be advocates for their community within the larger organization in order to:
 
-Make sure that a contributor's work is directly relevant to his own team's goals
-Get recognition for contributors
-Show potential contributors and their managers why it benefits them to contribute
-Encourage contributors to take on more responsibility
+. Make sure that a contributor's work is directly relevant to his own team's goals
+. Get recognition for contributors
+. Show potential contributors and their managers why it benefits them to contribute
+. Encourage contributors to take on more responsibility
 
-Correct answers: 2, 3, and 4
+===== Correct answers: 2, 3, and 4
 
 Why 1 is incorrect: Contributors work on another team’s code in order to meet the needs of the contributor’s team. The contribution should not break anything, of course, so it should not be in direct contradiction to the goals of the trusted committer’s team. But the relevance applies to the contributor’s team, not the trusted committer’s team.
 
@@ -244,19 +244,19 @@ Why 2 is correct: Recognition is both personally satisfying and potentially a st
 Why 3 and 4 are correct: Contributors are more likely to invest time and effort when they see that the project benefits them and is appreciated throughout the organization.
 
 
-SEGMENT: Becoming a Trusted Committer
+=== SEGMENT: Becoming a Trusted Committer
 
-NOTE:
+TIP:
 More than one answer may be correct in some questions.
 
-Question 1. If you become a trusted committer, you should expect to:
+==== Question 1. If you become a trusted committer, you should expect to:
 
-Work with a narrow range of contributions
-Spend more time coding
-Handle stressful situations on a project
-Allow the community to scrutinize your behavior
+. Work with a narrow range of contributions
+. Spend more time coding
+. Handle stressful situations on a project
+. Allow the community to scrutinize your behavior
 
-Correct answers: 3 and 4
+===== Correct answers: 3 and 4
 
 Why 1 is incorrect: Trusted committers tend to expand the scope of their work, not narrow the scope. As a trusted committer, you will work with a variety of people from different teams.
 
@@ -266,14 +266,14 @@ Why 3 is correct: A trusted committer takes personal responsibility for the heal
 
 Why 4 is correct: A trusted committer is not just a technical expert but a role model for behavior. Thus, you should be transparent in your behavior and willing to receive feedback from project participants.
 
-Question 2. Meritocracy in InnerSource, among other things, calls for:
+==== Question 2. Meritocracy in InnerSource, among other things, calls for:
 
-Recognizing the value of trusted committers as communicators
-Restricting each team to just a few trusted committers
-Keeping the best programmers on coding tasks instead of making them trusted committers
-Meeting all the deadlines set by management
+. Recognizing the value of trusted committers as communicators
+. Restricting each team to just a few trusted committers
+. Keeping the best programmers on coding tasks instead of making them trusted committers
+. Meeting all the deadlines set by management
 
-Correct answer: 1
+===== Question: 1
 
 Why 1 is correct: Many technical projects place great value on technical skills--which are certainly necessary--but undervalue what they dismissively call “soft” skills such as communication, problem-solving, and training. InnerSource is a community, and communities require these additional skills. A trusted committer is chosen and recognized for the full range of skills necessary to induce contributions.
 
@@ -283,14 +283,14 @@ Why 3 is incorrect: Because trusted committers vet other contributors code and m
 
 Why 4 is incorrect: InnerSource focuses on quality code and community-building, not deadlines. InnerSource can sometimes help a team meet its deadlines, because the team can recruit people temporarily from other teams on critical tasks. However, at other times, trusted committers request extensions to deadlines in order to ensure quality.
 
-Question 3.  Which are primary attributes of a good candidate for trusted committer?
+==== Question 3.  Which are primary attributes of a good candidate for trusted committer?
 
-Already made successful contributions to the project.
-Is on the host team for the project.
-Actively helps others in the community with questions.
-Participates in conversations on project roadmap and management.
+. Already made successful contributions to the project.
+. Is on the host team for the project.
+. Actively helps others in the community with questions.
+. Participates in conversations on project roadmap and management.
 
-Correct answers: 1, 3, 4
+===== Correct answers: 1, 3, 4
 
 Why 1 is correct: One of the primary responsibilities of a trusted committer is to help others to contribute successfully to the project.  A trusted committer must have a history of doing so themselves in order to be qualified to help others to do the same.
 
@@ -300,14 +300,14 @@ Why 3 is correct: A large part of a trusted committer’s responsibilities invol
 
 Why 4 is correct: The trust placed in a trusted committer extends beyond purely technical considerations. Trusted committers also communicate with the product owner and management.  Interest in these areas indicates someone that may be a good trusted committer.
 
-Question 4: What are some benefits of becoming a trusted committer?
+==== Question 4: What are some benefits of becoming a trusted committer?
 
-Taking on additional responsibility in a project prepares you for expanded leadership in the company.
-Being in a position of teaching others helps you to understand the project and code better yourself.
-You can expect an increase in monetary compensation at the time of assuming the responsibilities of Trusted Committer.
-Your impact on the project expands as you help to shepherd and guide more contributions than you’d have time to write yourself.
+. Taking on additional responsibility in a project prepares you for expanded leadership in the company.
+. Being in a position of teaching others helps you to understand the project and code better yourself.
+. You can expect an increase in monetary compensation at the time of assuming the responsibilities of Trusted Committer.
+. Your impact on the project expands as you help to shepherd and guide more contributions than you’d have time to write yourself.
 
-Correct answers: 1, 2, 4
+===== Correct answers: 1, 2, 4
 
 Why 1 is correct: Acting as a trusted committer is a great stretch role to build the same leadership skills that will be required if you decide to pursue a full-time leadership role later on. 
 
@@ -317,14 +317,14 @@ Why 3 is incorrect: It is not common that an immediate monetary increase is dire
 
 Why 4 is correct: Being a trusted committer is a force multiplier on your impact within the project.  As you mentor and uplevel contributors, each of their contributions will carry your mark and influence with them.  This effect results in your improving and adding to the project many times faster than you could just by heads-down coding on your own.
 
-Question 5: Which of the following describes the mechanics of becoming a trusted committer?
+==== Question 5: Which of the following describes the mechanics of becoming a trusted committer?
 
-Company management moves the person that they want to be leading the project into the role.
-The community or its leadership nominates new trusted committers.
-Anyone who is interested volunteers.
-The project founder assumes the role.
+. Company management moves the person that they want to be leading the project into the role.
+. The community or its leadership nominates new trusted committers.
+. Anyone who is interested volunteers.
+. The project founder assumes the role.
 
-Correct answers: 2 and 4.
+===== Correct answers: 2 and 4.
 
 Why 1 is incorrect:  The principle of meritocracy teaches Trusted Committership is earned, not assigned.  It’s also the case that the Trusted Committer should voluntarily accept an invitation to serve rather than being conscripted into the role.
 


### PR DESCRIPTION
This pull request contains the Trusted Committer section of the Learning Path Google Doc moved. 
- Currently in blank form, will be transformed to ASCIIdoc later. 
- However, everyone is welcome to add the required markup as commit suggestions and I'm happy to merge them in.