### PR TITLE
Atlas sync

### DIFF
--- a/.github/workflows/SyncToAtlas.yml
+++ b/.github/workflows/SyncToAtlas.yml
@@ -42,7 +42,7 @@ jobs:
         git push oreilly oreilly-master:master
     - name: Trigger build on Atlas
       run: |
-        gem install atlas
+        gem install atlas-api
         atlas build $OREILLYAPISECRET lenucksi/learningpath-introduction pdf,epub master
       env:
         OREILLYAPISECRET: ${{ secrets.OREILLYAPISECRET }}

--- a/.github/workflows/SyncToAtlas.yml
+++ b/.github/workflows/SyncToAtlas.yml
@@ -1,0 +1,48 @@
+name: Sync Master to Atlas Repos
+
+on: 
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  atlas:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@master 
+    - name: Add O'Reilly remotes
+      run: |
+        git remote add oreilly git@git.atlas.oreilly.com:lenucksi/learningpath-introduction.git
+    - uses: fregante/setup-git-token@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: enable SSH-Key
+      env: 
+        OREILLYKEY: ${{ secrets.OREILLYKEY }}
+      run: |
+        mkdir -p $HOME/.ssh
+        #ls -al ~/.ssh
+        echo -e "$OREILLYKEY" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+        eval `ssh-agent -s`
+        ssh-add ~/.ssh/id_rsa
+        ssh-keyscan git.atlas.oreilly.com >> ~/.ssh/known_hosts
+        #    - name: checkout master
+        #      run: git checkout master
+    - name: push master to oreilly repo
+      run: |
+        # What will happen here?
+        # We've got the repo local and need to merge two histories.
+        # O'Reilly master has extra content, not conflicting with ours though. Fetch it and check it out
+        # Get our master into a different branch. Merge our master-branch into the O'Reilly master.
+        # Push our new merged master into the O'Reilly master.
+        # Party!
+        git fetch oreilly
+        git checkout -b oreilly-master oreilly/master
+        git merge -m "Merge GitHub content to Atlas" -v --commit --log master 
+        git push oreilly oreilly-master:master

--- a/.github/workflows/SyncToAtlas.yml
+++ b/.github/workflows/SyncToAtlas.yml
@@ -46,3 +46,9 @@ jobs:
         git checkout -b oreilly-master oreilly/master
         git merge -m "Merge GitHub content to Atlas" -v --commit --log master 
         git push oreilly oreilly-master:master
+    - name: Trigger build on Atlas
+      run: |
+        gem install atlas
+        atlas build $OREILLYAPISECRET lenucksi/learningpath-introduction pdf,epub master
+      env:
+        OREILLYAPISECRET: ${{ secrets.OREILLYAPISECRET }}

--- a/.github/workflows/SyncToAtlas.yml
+++ b/.github/workflows/SyncToAtlas.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
     - master
-  pull_request:
-    branches:
-    - master
 
 jobs:
   atlas:
@@ -26,20 +23,17 @@ jobs:
         OREILLYKEY: ${{ secrets.OREILLYKEY }}
       run: |
         mkdir -p $HOME/.ssh
-        #ls -al ~/.ssh
         echo -e "$OREILLYKEY" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
         eval `ssh-agent -s`
         ssh-add ~/.ssh/id_rsa
         ssh-keyscan git.atlas.oreilly.com >> ~/.ssh/known_hosts
-        #    - name: checkout master
-        #      run: git checkout master
     - name: push master to oreilly repo
       run: |
         # What will happen here?
         # We've got the repo local and need to merge two histories.
         # O'Reilly master has extra content, not conflicting with ours though. Fetch it and check it out
-        # Get our master into a different branch. Merge our master-branch into the O'Reilly master.
+        # Merge our master-branch into the O'Reilly master.
         # Push our new merged master into the O'Reilly master.
         # Party!
         git fetch oreilly


### PR DESCRIPTION
This GitHub Actions pipeline synchronizes our repo content on changes to master to the O'Reilly Atlas repository and merges in the local specifics to enable rendering the content properly.

As a last step a build on O'Reilly is triggered using the Gem described here: http://docs.atlas.oreilly.com/api.html

Secrets live in the project and run off of my account first. Having a bot account for that purpose probably would do no harm though.

Once this works, extending it to the other repos is a quick fix.

**TODO:** I might need to add runs using the actual `GITHUB_SHA` of the current state to enable using this as a pull request check. Or might need to add a second pipeline running against pull request checks separating the sync run on pushes to master and the pull request check run.