### PR TITLE
Remove tip about creating a conference call

### DIFF
--- a/meetings/roles.md
+++ b/meetings/roles.md
@@ -26,7 +26,6 @@ The _Scheduler_ sends the calendar invite for the meeting.
 
 ### Tips
 
-* You can use your favorite corporate conference call system or create a Google Hangout.
 * Check out this [writeup][gdoc sharing] if you need help creating a write-enabled link to the agenda document.
 
 <a name="crier"></a>


### PR DESCRIPTION
We just have a single conference call for the whole series now.