### PR TITLE
Atlas TC edits merge back to github - 01 intro

### DIFF
--- a/contributor/05-benefits-of-contribution-article.asciidoc
+++ b/contributor/05-benefits-of-contribution-article.asciidoc
@@ -25,8 +25,8 @@ daily work to reduce the number of workarounds in their own codebase.
 
 When deciding whether to create and contribute a fix instead of maintaining your
 own workaround, think about the benefit that the contribution will bring to
-the quality of your own fix. Instead of working in isolation, those in the upstream
-project will be able to not only review, but also improve your solution. You get
+the quality of your own changes. Instead of working in isolation, those working on the upstream
+project will be able to not only review but also improve your solution. You get
 support and mentoring which greatly speeds up your own development effort.
 
 Spending more time with others means that over time you will learn how the team
@@ -41,7 +41,7 @@ challenges.
 A nice side effect of being able to spend some of your time in other teams is
 that your reputation and impact expand the boundaries of your own team. So in
 addition to learning from others and growing yourself, you get to influence
-projects.  You influence directly via your own contributions and by
+projects. You influence directly via your own contributions and by
 sharing your experience and knowledge on project tooling and setup. This sharing might
 help the upstream project improve and accelerate development cycles.
 
@@ -51,36 +51,36 @@ projects alike: people participate because they find work on those projects
 personally fulfilling and fun. Most likely, the aspect of being in a position
 to truly self select tasks to work on does play an important role.
 This self selection typically also leads to host projects being very welcoming
-and supportive in their effort to attract motivated contributors.
+and supportive in their effort to keep contributors motivated.
 
 === Team level motivation
 
-Remember that annoying bug that's suddenly fixed upstream? Why should your
-team spend the extra effort to contribute that fix to the upstream project?
+Remember that annoying bug that's been finally fixed upstream? Why should your
+team spend an extra effort to contribute that fix to the upstream project?
 
-For one it means that maintenance cost and time is now with the upstream
+For one, it means that maintenance cost and time is now with the upstream
 project.  For every new release it's on them instead of on your team to make sure it
 keeps working with your modifications and requirements.
 
 Having team members work as active contributors in projects your team depends on
-means that likely they will get to have a say in project direction and timelines,
+means that they may get to have a say in the project direction and timelines,
 which can be beneficial for your team.
 
 By using InnerSource teams can establish a middle path between "be independent
 and build your own" (including any number of new bugs that you own) and "save
 time and money by relying on existing implementations" (at the cost of creating
-long term dependencies that can only be influenced in a limited way). That way
-balancing reimplementing versus reusing becomes easier.
+long term dependencies which can only be influenced in a limited way). That way
+balancing reimplementing versus reuse becomes easier.
 
 === Company motivation
 
 Remember that functionality that's specific to your company domain - but that
 is maintained in mutiple implementations across the entire company? What if
 there were a way to avoid a dozen buggy implementations and merge them into a
-shared asset with a development process attached that avoids the usual
+shared asset? What if the development process for this shared asset ran without the usual
 drain of energy that central dependencies bring to the table? Many open source
-projects are being used by a huge number of players - some of which participate
-in their design and development. Encouraging cross team collarboration in InnerSource
+projects are being used by a huge number of players - some of who participate
+in their design and development. Encouraging cross team collaboration in InnerSource
 projects at the corporate level means that you can drive central
 innovation from the edges of your organisation.
 
@@ -92,25 +92,25 @@ projects transparent, but also provides tools to improve that situation by
 putting focus on mentoring and expanding the contributor base.
 
 While cross team collaboration makes assessing individual contributions hard,
-it also enables learning and knowledge sharing withing an organisation. As a
+it also enables learning and knowledge sharing within the organisation. As a
 result, the impact of individuals will improve. Best practices and positive
 innovation will spread more easily across the entire organisation. As a side
 effect, improvements to the work environment will more easily spread across the
 organization - helping retain employees.
 
-On the technological side more eyes with a more diverse background implies that
+On the technological side having more eyes with a more diverse background implies that
 code changes will be put under much more scrutiny, leading to better overall
 quality and security.
 
-Finally, a focus on enabling project users and customers to participate in
-development means that there is a very clear incentive to make these projects
-easy to get started with: Based on standard tooling, easy to understand, easy to
+Finally, the focus on enabling project users and customers to participate in
+development provides a very clear incentive to make these projects
+easy to get started with: based on standard tooling, easy to understand, easy to
 re-use and as a result more modular and replaceable.
 
 === Conclusion
 
 As we've seen in this article, many of the reasons for individuals and
 corporations to get active in Open Source also apply to InnerSource projects.
-What we've seen as well is that it's not only altruistic reasons that drive
+We have also seen that it's not only altruistic reasons that drive
 people to collaborate in InnerSource projects - often it's easy to identify
 business reasons for when collaboration like this makes a lot of sense.

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -1,81 +1,81 @@
-== Introducing the Trusted Committer role
+[role="pagenumrestart"]
+== Introducing the Trusted Committer Role
 
-The Trusted Committer (TC) role is one of the key roles in an InnerSource
-community. Think of Trusted Committers as the people in a community that you trust with
-important technical decisions and with mentoring contributors in order to get
-their contribution over the finish line. The Trusted Committer role is both a demanding and a
-rewarding role to fulfill. It goes far beyond being an opinionated gatekeeper
-and it is instrumental for the success of any InnerSource community.
+The Trusted Committer (TC) role is one of the key roles in an
+InnerSource community. Think of Trusted Committers as the people in a community that
+you trust with important technical decisions and with mentoring
+contributors to ultimately get contributions over the finish line.
+The TC role is both demanding and rewarding. It is more than just being an opinionated gatekeeper and is instrumental for
+the success of any InnerSource community.
 
-Generally speaking, the Trusted Committer role is defined by its responsibilities, rather than
-by its privileges. On a very high level, Trusted Committers represent the interests of both
-their InnerSource community and the products the community is building. They
-are concerned with the health of both the community and the product. So as a
-Trusted Committer, you'll have both tech oriented and community oriented responsibilities.  We'll
-explore both of these dimensions in the following sections.
+Generally speaking, the Trusted Committer role is defined by its responsibilities,
+rather than by its privileges. On a very high level, TCs represent the
+interests of both their InnerSource community and the products the
+community is building. They are concerned with the health of both the
+community and the product. So as a Trusted Committer, you’ll have both 
+tech- and community-oriented responsibilities. We’ll explore both of these
+dimensions in the following sections.
 
-Before we go into the details of what a Trusted Committer actually does, let's spend some time
-contrasting the Trusted Committer role to other roles in InnerSource on a high level of abstraction and
-explain why we think the name is both apt and important.  Let's
-start with the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributor_] role. A _Contributor_ - as the name implies -
-makes contributions to an InnerSource community.  These contributions could be code or non-code
-artifacts, such as bug reports, feature requests or documentation.
+Before we go into the details of what a Trusted Committer actually does, let’s spend
+some time contrasting the Trusted Committer role with other roles in InnerSource at a
+high level of abstraction and explain why we think the name is both apt
+and important. Let’s start with the _Contributor_ role. A
+_Contributor_ — as the name implies—makes contributions to an InnerSource
+community. These contributions could be code or non-code artifacts, such
+as bug reports, feature requests, or documentation.
 
-_Contributors_ might or might not be part of the community. They might be sent by
-another team to develop a feature that their team needs. This is why we
-sometimes also refer to _Contributors_ as _Guests_ or being part of a _Guest
-Team_. The _Contributor_ is responsible for "fitting in" and for conforming to the
-community's expectations and processes.
+_Contributors_ may or may not be part of the community. They might
+be sent by another team to develop a feature the team needs. This
+is why we sometimes also refer to _Contributors_ as _Guests_ or as
+part of a _Guest Team_. The _Contributor_ is responsible for "fitting
+in" and for conforming to the community’s expectations and processes.
 
-The _Trusted Committer_ is always a member of the InnerSource community, which is
-also sometimes referred to as the _Host Team_. In this analogy, the Trusted Committer is
-responsible for both building the house and setting the house rules, to make
-sure their guests are comfortable and can work together effectively. Compared
-to contributors, Trusted Committers have earned the responsibility to push code closer to
-production, and are generally allowed to perform tasks that have a higher level
-of risk associated with them.
+The _Trusted Committer_ is always a member of the InnerSource community,
+which is also sometimes referred to as the _Host Team_. In this analogy,
+the Trusted Committer is responsible for both building the house and setting the house
+rules to ensure their guests are comfortable and can work together
+effectively. Compared to contributors, Trusted Committers have earned the
+responsibility to push code closer to production and are generally
+allowed to perform tasks that have a higher level of risk associated
+with them.
 
-The https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_ (PO)] is the third role in InnerSource.  Similar to agile
-processes, the PO is responsible for defining and prioritizing requirements and
-stories for the community to implement. The PO interacts often with the
-Trusted Committer, e.g. in making sure that a requested or contributed feature actually
-belongs to the product. Especially in smaller, grass-roots type InnerSource
-communities, the Trusted Committer usually also acts as a PO. Please check out our https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[Product
-Owner Learning Path segment] for more detailed information.
+The _Product Owner_ (PO) is the third role in InnerSource. Similar to
+agile processes, the PO is responsible for defining and prioritizing
+requirements and stories for the community to implement. The PO
+interacts often with the Trusted Committer, (e.g., in making sure that a requested or
+contributed feature actually belongs to the product). Especially in
+smaller, grassroots InnerSource communities, the Trusted Committer usually also
+acts as a PO. Check out our https://learning.oreilly.com/videos/innersource-product-owners/9781492046707[Product Owner Learning Path segment]
+for more detailed information.
 
+=== Why Role Names Matter
 
-=== Why role names matter
+The role of the Trusted Committer is present in every successful InnerSource community
+but not every community uses that name. Some communities use the term
+Maintainer, but this term conflicts with other technical roles such as the 
+"Maintainer" role defined by GitHub, for instance. Apache uses the term
+_Committer_, too, but they attach fewer and mostly tech-oriented
+responsibilities to that role. With its additional community-oriented responsibilities, 
+the TC role goes beyond that. The ``Trusted'' in Trusted Committer
+means this person is trusted and thus empowered by both their
+management and their community to do their job. By fostering openness
+and transparency, Trusted Committers build trust in the process and also in the product
+being built.
 
-The role of the Trusted Committer is present in every successful InnerSource community, but not
-every community uses that name. Some communities use the term Maintainer, but
-it turns out that it conflicts with the technical role "Maintainer" defined by
-GitHub, for instance.  Apache uses the term _Committer_, too, but they attach
-fewer and mostly tech oriented responsibilities to that role. The Trusted Committer role with
-its additional community oriented responsibilities goes beyond that.  The
-"Trusted" in Trusted Committer conveys that they are trusted and thus empowered by both their
-management and their community to do their job. By fostering openness and
-transparency, Trusted Committers build trust in the process and also in the product being
-built.
+Similar to how naming is important in writing software, choosing the right names for roles and
+doing so consistently ensures that everyone has the same understanding about the roles played in the community.
 
-So similar to how naming is important in writing software, it is important for the
-roles in an InnerSource project as well. Choosing the right names and doing so
-consistently ensures that everyone has the same notion of the role and how it
-serves the community.
+Now that you have a basic understanding of the role, why using the
+term TC is appropriate, and know how a Trusted Committer might interact with other common roles in a software project, let's take a quick look at the responsibilities of a Trusted Committer.
 
-Now you should have a basic understanding of the role, why using the term
-_Trusted Committer_ is appropriate, and understand how a Trusted Committer might
-interact with other common roles in a software project.
+=== Responsibilities
 
-=== Responsibilities 
+Trusted Committers have various responsibilities, including:
 
-In the following segments, we'll dive into the various responsibilities that
-Trusted Committers have:
+* Ensuring product quality
+* Keeping the community healthy
+* Reducing the barriers to making contributions
+* Upleveling the community
+* Advocating the community's needs
 
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/02-ensuring-product-quality.asciidoc[ensuring product quality],
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/03-keeping-the-community-healthy.asciidoc[keeping the community healthy],
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc[reducing the barrier to making contributions],
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/04-uplevelling-community-members.asciidoc[upleveling the community],
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc[advocating the communities needs].
-
-In addition, we will also explore the path of https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/07-becoming-a-trusted-committer.asciidoc[becoming a Trusted Committer] in the end
-of this article.
+We will look at these responsibilities in more depth in the following pages and also explore the path of becoming a Trusted Committer at the end of this article.

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -57,7 +57,7 @@ Maintainer, but this term conflicts with other technical roles such as the
 "Maintainer" role defined by GitHub, for instance. Apache uses the term
 _Committer_, too, but they attach fewer and mostly tech-oriented
 responsibilities to that role. With its additional community-oriented responsibilities, 
-the TC role goes beyond that. The ``Trusted'' in Trusted Committer
+the TC role goes beyond that. The "Trusted" in Trusted Committer
 means this person is trusted and thus empowered by both their
 management and their community to do their job. By fostering openness
 and transparency, Trusted Committers build trust in the process and also in the product

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -5,11 +5,12 @@ The Trusted Committer (TC) role is one of the key roles in an
 InnerSource community. Think of Trusted Committers as the people in a community that
 you trust with important technical decisions and with mentoring
 contributors to ultimately get contributions over the finish line.
-The TC role is both demanding and rewarding. It is more than just being an opinionated gatekeeper and is instrumental for
+The Trusted Committer role is both demanding and rewarding. It is 
+more than just being an opinionated gatekeeper and is instrumental for
 the success of any InnerSource community.
 
 Generally speaking, the Trusted Committer role is defined by its responsibilities,
-rather than by its privileges. On a very high level, TCs represent the
+rather than by its privileges. On a very high level, Trusted Committers represent the
 interests of both their InnerSource community and the products the
 community is building. They are concerned with the health of both the
 community and the product. So as a Trusted Committer, you’ll have both 
@@ -66,7 +67,9 @@ Similar to how naming is important in writing software, choosing the right names
 doing so consistently ensures that everyone has the same understanding about the roles played in the community.
 
 Now that you have a basic understanding of the role, why using the
-term TC is appropriate, and know how a Trusted Committer might interact with other common roles in a software project, let's take a quick look at the responsibilities of a Trusted Committer.
+term Trusted Committer is appropriate, and know how a Trusted Committer 
+might interact with other common roles in a software project, let's take 
+a quick look at the responsibilities of a Trusted Committer.
 
 === Responsibilities
 

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -66,7 +66,7 @@ Now you should have a basic understanding of the role, why using the term
 _Trusted Committer_ is appropriate, and understand how a Trusted Committer might
 interact with other common roles in a software project.
 
-=== Responsibilities
+=== Responsibilities 
 
 In the following segments, we'll dive into the various responsibilities that
 Trusted Committers have:

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -20,7 +20,7 @@ dimensions in the following sections.
 Before we go into the details of what a Trusted Committer actually does, let’s spend
 some time contrasting the Trusted Committer role with other roles in InnerSource at a
 high level of abstraction and explain why we think the name is both apt
-and important. Let’s start with the _Contributor_ role. A
+and important. Let’s start with the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributor_] role. A
 _Contributor_ — as the name implies—makes contributions to an InnerSource
 community. These contributions could be code or non-code artifacts, such
 as bug reports, feature requests, or documentation.
@@ -40,7 +40,7 @@ responsibility to push code closer to production and are generally
 allowed to perform tasks that have a higher level of risk associated
 with them.
 
-The _Product Owner_ (PO) is the third role in InnerSource. Similar to
+The https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_ (PO)] is the third role in InnerSource. Similar to
 agile processes, the PO is responsible for defining and prioritizing
 requirements and stories for the community to implement. The PO
 interacts often with the Trusted Committer, (e.g., in making sure that a requested or
@@ -75,10 +75,10 @@ a quick look at the responsibilities of a Trusted Committer.
 
 Trusted Committers have various responsibilities, including:
 
-* Ensuring product quality
-* Keeping the community healthy
-* Reducing the barriers to making contributions
-* Upleveling the community
-* Advocating the community's needs
+* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/02-ensuring-product-quality.asciidoc[Ensuring product quality]
+* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/03-keeping-the-community-healthy.asciidoc[Keeping the community healthy]
+* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc[Reducing the barriers to making contributions]
+* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/04-uplevelling-community-members.asciidoc[Upleveling the community]
+* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc[Advocating the community's needs]
 
-We will look at these responsibilities in more depth in the following pages and also explore the path of becoming a Trusted Committer at the end of this article.
+We will look at these responsibilities in more depth in the following pages and also explore the path of https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/07-becoming-a-trusted-committer.asciidoc[becoming a Trusted Committer] at the end of this article.

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -57,7 +57,7 @@ Maintainer, but this term conflicts with other technical roles such as the
 "Maintainer" role defined by GitHub, for instance. Apache uses the term
 _Committer_, too, but they attach fewer and mostly tech-oriented
 responsibilities to that role. With its additional community-oriented responsibilities, 
-the TC role goes beyond that. The "Trusted" in Trusted Committer
+the Trusted Committer role goes beyond that. The "Trusted" in Trusted Committer
 means this person is trusted and thus empowered by both their
 management and their community to do their job. By fostering openness
 and transparency, Trusted Committers build trust in the process and also in the product


### PR DESCRIPTION
This PR is for the introduction article only.
Changed TC back to Trusted Committer; re-added the links. Kept their style suggestions.