### PR TITLE
Articles link to isc website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 \.DS_Store
+scripts/node_modules

--- a/config/urls.yaml
+++ b/config/urls.yaml
@@ -8,7 +8,7 @@
   # URLs of video locations.
   video:
     # URL on the innersourcecommons.org site.
-    isc: https://innersourcecommons.org/resources/learningpath/introduction/
+    isc: https://innersourcecommons.org/resources/learningpath/introduction/index
     # URL on the O'Reilly learning plarform.
     oreilly: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321606
     # URL on YouTube.
@@ -19,7 +19,7 @@
     # URL in GitHub.
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/01-introduction.asciidoc
     # URL on the innersourcecommons.org site.
-    isc: https://innersourcecommons.org/resources/learningpath/introduction/
+    isc: https://innersourcecommons.org/resources/learningpath/introduction/index
     # URL on the O'Reilly learning plarform.
     oreilly: ''
 - section: introduction
@@ -74,13 +74,13 @@
     oreilly: ''
 - section: trusted committer
   video:
-    isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/
+    isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/index
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323925
     youtube: https://www.youtube.com/watch?v=TKdqjkPJWNU
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc
-    isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/
+    isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/index
     oreilly: ''
 - section: trusted committer
   video:
@@ -154,13 +154,13 @@
     oreilly: ''
 - section: product owner
   video:
-    isc: https://innersourcecommons.org/resources/learningpath/product-owner/
+    isc: https://innersourcecommons.org/resources/learningpath/product-owner/index
     oreilly: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707/9781492046707-video325229
     youtube: https://www.youtube.com/watch?v=5DXUljspcA4
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc
-    isc: https://innersourcecommons.org/resources/learningpath/product-owner/
+    isc: https://innersourcecommons.org/resources/learningpath/product-owner/index
     oreilly: ''
 - section: product owner
   video:
@@ -214,13 +214,13 @@
     oreilly: ''
 - section: contributor
   video:
-    isc: https://innersourcecommons.org/resources/learningpath/contributor/
+    isc: https://innersourcecommons.org/resources/learningpath/contributor/index
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329499
     youtube: https://www.youtube.com/watch?v=_LNtwShi_XI
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc
-    isc: https://innersourcecommons.org/resources/learningpath/contributor/
+    isc: https://innersourcecommons.org/resources/learningpath/contributor/index
     oreilly: ''
 - section: contributor
   video:

--- a/config/urls.yaml
+++ b/config/urls.yaml
@@ -3,6 +3,7 @@
 # This information is useful when mapping or converting one URL to another,
 # such as when generating a version of an article to be hosted on a specific platform
 ---
+
 - section: introduction
   # URLs of video locations.
   video:
@@ -78,7 +79,7 @@
     youtube: https://www.youtube.com/watch?v=TKdqjkPJWNU
   article:
     anchor: ''
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/01-introduction.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/
     oreilly: ''
 - section: trusted committer
@@ -88,7 +89,7 @@
     youtube: https://www.youtube.com/watch?v=06cVAAwgsZA
   article:
     anchor: ''
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/02-ensuring-product-quality.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/02-ensuring-product-quality.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/02/
     oreilly: ''
 - section: trusted committer
@@ -98,7 +99,7 @@
     youtube: https://www.youtube.com/watch?v=930UIbjiXZc
   article:
     anchor: ''
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/03-keeping-the-community-healthy.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/03-keeping-the-community-healthy.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/03/
     oreilly: ''
 - section: trusted committer
@@ -108,7 +109,7 @@
     youtube: https://www.youtube.com/watch?v=o7geZaX7i7I
   article:
     anchor: pass:[<a data-type="xref" href="upleveling" data-xrefstyle="chap-num-title">#upleveling</a>]
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/04-uplevelling-community-members.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/04-uplevelling-community-members.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/04/
     oreilly: ''
 - section: trusted committer
@@ -118,7 +119,7 @@
     youtube: https://www.youtube.com/watch?v=Lnz54hlKC-I
   article:
     anchor: ''
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/05/
     oreilly: ''
 - section: trusted committer
@@ -128,7 +129,7 @@
     youtube: https://www.youtube.com/watch?v=ucQA8mp012Q
   article:
     anchor: pass:[<a data-type="xref" href="advocating" data-xrefstyle="chap-num-title">#advocating</a>]
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/06/
     oreilly: ''
 - section: trusted committer
@@ -138,7 +139,7 @@
     youtube: https://www.youtube.com/watch?v=jA1p01FEHj4
   article:
     anchor: ''
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/07-becoming-a-trusted-committer.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/07-becoming-a-trusted-committer.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/07/
     oreilly: ''
 - section: trusted committer
@@ -148,7 +149,7 @@
     youtube: https://www.youtube.com/watch?v=n982OcEfyQE
   article:
     anchor: ''
-    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/tree/master/trusted-committer/08-conclusion.asciidoc
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/08-conclusion.asciidoc
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/08/
     oreilly: ''
 - section: product owner

--- a/contributor/01-introduction-article.asciidoc
+++ b/contributor/01-introduction-article.asciidoc
@@ -12,15 +12,15 @@ If you're not getting what you need, you can make the change you need directly i
 The Contributor role describes a person that makes contributions to the repos of an InnerSource community project.
 This person may or may not be part or see themselves as part of the community.
 However, for quite a few people there is a sort of journey that contributors can make from just knowing about the community to using the community's product to interacting with members of the community and finally starting to contribute.
-Finally, some of them may become https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[Trusted Committers].
+Finally, some of them may become https://innersourcecommons.org/resources/learningpath/trusted-committer/index[Trusted Committers].
 
 === Relationship to other roles
 
-As a Contributor in an InnerSource community you will interact with people playing other roles of InnerSource, such as https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] or https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_] and possibly with other contributors.
+As a Contributor in an InnerSource community you will interact with people playing other roles of InnerSource, such as https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] or https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_] and possibly with other contributors.
 At times, these roles can be played by the same person, such as Trusted Committer and Product Owner in small grassroots style projects.
 
-This section gives you a very short overview of the other two roles, but we'd like to encourage you to read the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[introductory article of the Trusted Committer role], and we recommended you read the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc[Lowering the barriers to entry] article, too, before you delve deeper into the details of the Contributor role in this section.
-You can also watch the videos (https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323925[introduction], https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323929[lowering the barriers to entry]) instead of reading the articles.
+This section gives you a very short overview of the other two roles, but we'd like to encourage you to read the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[introductory article of the Trusted Committer role], and we recommended you read the https://innersourcecommons.org/resources/learningpath/trusted-committer/05/[Lowering the barriers to entry] article, too, before you delve deeper into the details of the Contributor role in this section.
+You can also watch the videos (https://innersourcecommons.org/resources/learningpath/trusted-committer/index[introduction], https://innersourcecommons.org/resources/learningpath/trusted-committer/05/[lowering the barriers to entry]) instead of reading the articles.
 
 ==== Trusted Committer
 
@@ -33,7 +33,7 @@ Caring for the community involves keeping it healthy, upleveling it and its part
 
 ==== Product Owner
 
-The role of the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_] has some similarity with the product owner role of your average project.
+The role of the https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_] has some similarity with the product owner role of your average project.
 However, there are differences - depending on the size of the project, this role is often filled by the same person that acts as trusted committer.
 In larger projects, or in teams that only partially use InnerSource as an approach to fill their needs by accepting contributions, this role is likely filled by a person separate from a trusted committer.
 
@@ -42,7 +42,7 @@ You might work with the product owner role to make sure that general aspects of 
 
 Last but not least, someone acting as product owner might have been involved in bringing the project, its benefits and community to your attention.
 
-If you want to learn in more detail what these other roles are about, and we encourage you to do so, we've prepared separate sections about the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] and the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_].
+If you want to learn in more detail what these other roles are about, and we encourage you to do so, we've prepared separate sections about the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] and the https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_].
 
 === Section overview
 

--- a/contributor/04-mechanics-of-contributing-article.asciidoc
+++ b/contributor/04-mechanics-of-contributing-article.asciidoc
@@ -36,7 +36,7 @@ This effect can be observed with Open Source as well, you can read more about it
 In your classic teams everyone had an idea of the expected lead times.
 Within an InnerSource context this might not be the case, either due to large time-zone differences (e.g. Seattle, USA with PDT vs Berlin, Germany with CEST) or you not being available full-time as with your original team, even if they are in the same physical location as you are.
 Thus, to prevent frustration on both sides, impatience and other non-trust-building effects, you'll need to explicitly do expectations management with regards to your expected reaction times.
-One approach is to just quickly react with a "I'll look into it, I won't get to it in the next few days though" to a https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer's_] feedback if you know that you'll only be able to come back to them in a few days.
+One approach is to just quickly react with a "I'll look into it, I won't get to it in the next few days though" to a https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer's_] feedback if you know that you'll only be able to come back to them in a few days.
 Ideally, you can provide them with a rough estimate when you will likely have time to take a look at their input.
 Doing so builds trust by reliability even over non-physical contact, longer distance or otherwise asynchronous media.
 Established trust will allow you to overcome uncertainty bumps in the collaborative road ahead of you.
@@ -60,7 +60,7 @@ This challenge is a frequent one, and many team relationships suffered from not 
 
 Make yourself and the host team happy (and possibly save some work) by getting agreement from the host team on the user/technical design of the contribution _before_ working on the changes and submitting a pull request.
 You'll have to understand how the host team would like you to reach out for this.
-It's best to ask a https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] about how to best discuss your proposal.
+It's best to ask a https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] about how to best discuss your proposal.
 
 It is time-and-again-proven wisdom from the Open Source arena that, if you get to select how to discuss your proposal, you should try to select a written way.
 Ideally, choose the way where artifacts are public, searchable and perma-linkable to enable referencing your proposal in later discussions on this future contribution or other contributions to come - by you or others.
@@ -103,19 +103,19 @@ Project teams are often happy to receive additions, updates or corrections for t
 
 We all have our preferences and opinions on code style, indentation, etc.
 The host team's project has them as well.
-Try to adapt and match those preferences even if it's not what you would normally do, and even if it is not specified in the projects' https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc[_`CONTRIBUTING.md`_].
+Try to adapt and match those preferences even if it's not what you would normally do, and even if it is not specified in the projects' https://innersourcecommons.org/resources/learningpath/trusted-committer/05/[_`CONTRIBUTING.md`_].
 If you are unsure, you can always ask politely. Nevertheless, a guest contribution for a feature or a bug fix is not the time to introduce a new way of structuring or formatting project code.
 
 === Submitting the pull request
 
 You've completed all the essential work, figured out all the quirks of the problem and the project you are contributing to, the time you've planned for the new feature to be used comes nearer, and you want to make sure your contribution gets merged in as fast and smooth as possible.
 
-Here's what you can do to make reviewing and merging as easy as possible for the the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] and the host team.
+Here's what you can do to make reviewing and merging as easy as possible for the the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] and the host team.
 This might actually be pretty similar to what you may already be doing on your own project to get your changes accepted. If that's the case - great, this is going to come natural to you!
 
 ==== Testing and automation
 
-The basic point here is to enable the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] to validate the contribution without your presence and to ensure easy maintainability.
+The basic point here is to enable the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] to validate the contribution without your presence and to ensure easy maintainability.
 Imagine you've built a feature or handling of an unsolvable quirk, or an important performance tweak, and your code is not entirely obvious (or might even look hacky / wrong at the first glance).
 If you have covered this with a test - and ideally have shed some words on the rationale behind it in a comment - a future editor will get reminded about the purpose of the code, and the test(s) will ensure that the value your code realizes will be kept, even in the new implementations.
 To achieve this, do the following:
@@ -141,11 +141,11 @@ To make the actual code review as easy as possible for the trusted committer or 
 * Provide a clear description of what this pull request changes, why it does so, and which issue and design documents (if there were any) it refers to.
 * If there is anything uncommon or unexpected in the pull request, highlight it and provide the explanation. This will make it easier to reason about and solve potential blocking questions that a reviewer might have during the review.
  ** The same goes for the scenario where you were unsure of the implementation or your approach - highlight it and ask for an insight.
- ** Be civil and expect civility from the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer's_] review.
+ ** Be civil and expect civility from the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer's_] review.
 * Making pull requests too broad and large makes them more difficult to review, so it will take much longer before they're accepted.
  ** If you have a larger feature that you are contributing, it often helps to split it in multiple pull requests that are submitted, reviewed and accepted sequentially.
 You can still bind them together with an issue that you are referring to.
-  *** Some tools also have Draft / WIP pull request functionality that you can use to explicitly mark unfinished and non-polished work and still get early feedback from your host team's https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/02-ensuring-product-quality.asciidoc[_Trusted Committers_].
+  *** Some tools also have Draft / WIP pull request functionality that you can use to explicitly mark unfinished and non-polished work and still get early feedback from your host team's https://innersourcecommons.org/resources/learningpath/trusted-committer/02/[_Trusted Committers_].
   *** This allows you to ensure that you are going down a path that your host team is happy to merge once it's done, adhering to the "release early, release often" idea in a way.
   *** The host team's responsibility is to create an atmosphere where sharing and discussing not-totally-polished work is possible and welcome. If you can't fail safe, you can't innovate, and collaboration becomes very hard.
   *** Try to balance between asking for a review early and providing meaningful changes to review.

--- a/contributor/outline.asciidoc
+++ b/contributor/outline.asciidoc
@@ -7,7 +7,7 @@
 * Summary of the roles of InnerSource and how each relates to _Contributor_.
 * Summary of the upcoming segments and what each covers.
 
-Outline for this section inspired by the https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323925[Trusted Committer introduction video].
+Outline for this section inspired by the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[Trusted Committer introduction video].
 
 === Becoming an InnerSource Contributor
 
@@ -143,4 +143,4 @@ Review what we've learned/taught together.
 * Summary of the other sections in the learning path with invitation to watch.
 * Summary of the InnerSource Commons and invitation to join.
 
-Outline for this section inspired by the https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323932[Trusted Committer conclusion].
+Outline for this section inspired by the https://innersourcecommons.org/resources/learningpath/trusted-committer/08/[Trusted Committer conclusion].

--- a/contributor/video-proposal.asciidoc
+++ b/contributor/video-proposal.asciidoc
@@ -42,8 +42,8 @@ This section teaches the mindset, the habits, technical approaches and other det
 ==== Prerequisites
 
 * Please watch the https://www.safaribooksonline.com/videos/introduction-to-innersource/9781492041504[Intro to InnerSource Video]
-* Also watch the https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323925[Introduction] to the Trusted Committer role.
-* The https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323929[Lowering the Barriers to Entry] video of the Trusted Committer role can be a good addition to understand more of why the Trusted Committer might ask for different things.
+* Also watch the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[Introduction] to the Trusted Committer role.
+* The https://innersourcecommons.org/resources/learningpath/trusted-committer/05/[Lowering the Barriers to Entry] video of the Trusted Committer role can be a good addition to understand more of why the Trusted Committer might ask for different things.
 
 ==== Materials or downloads needed in advance
 

--- a/introduction/03-how-works.asciidoc
+++ b/introduction/03-how-works.asciidoc
@@ -20,9 +20,9 @@ These concepts around a home visit are a metaphor for the attitude and behaviors
 
 Let's take a closer look at how the mechanics of the InnerSource process can work.
 To aid in this explanation, we'll name a few key individuals on the guest and host teams.
-First, the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_] determines what functionality the host team is willing to accept as a contribution.
-The https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributor_] is the individual on the guest team that submits the code contribution for review by the host team.
-The https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] represents the host team in providing any timely support and mentorship that the contributor needs to successfully submit the pull request.
+First, the https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_] determines what functionality the host team is willing to accept as a contribution.
+The https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributor_] is the individual on the guest team that submits the code contribution for review by the host team.
+The https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] represents the host team in providing any timely support and mentorship that the contributor needs to successfully submit the pull request.
 On small, grass roots efforts a single person often fills _both_ the product owner and trusted committer roles.
 
 With those definitions, here is the basic outline of an InnerSource contribution.

--- a/introduction/04-benefits.asciidoc
+++ b/introduction/04-benefits.asciidoc
@@ -21,7 +21,7 @@ Beyond the raw work that the host team is able to accomplish in its system, regu
 A host team can do its best requirements gathering on the work it produces, but when the consumer itself is the one submitting the work the chances are much higher that the resulting change is aligned to just what the consumer needs.
 While it may be only one single guest team submitting the change, that team is likely representative of many other consumers.
 
-In addition to this alignment, there is also a general training and education of https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[contributors] as they work with and learn from https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[trusted committers].
+In addition to this alignment, there is also a general training and education of https://innersourcecommons.org/resources/learningpath/contributor/index[contributors] as they work with and learn from https://innersourcecommons.org/resources/learningpath/trusted-committer/index[trusted committers].
 This interaction helps contributors to learn and grow in their career, resulting in *higher job satisfaction*.
 Project documentation improves to enable these contributions at scale.
 Contributors feel a stake in the host team project.

--- a/introduction/05-principles.asciidoc
+++ b/introduction/05-principles.asciidoc
@@ -45,8 +45,8 @@ This communication should be done in a manner that can be easily queried and und
 
 === Prioritized Mentorship
 
-_Mentorship_ from host team to guest team via https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[trusted committers] is a key aspect of InnerSource.
-https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[Contributors] on guest teams are upleveled so that they understand enough about the host team's project/repo to change it successfully.
+_Mentorship_ from host team to guest team via https://innersourcecommons.org/resources/learningpath/trusted-committer/index[trusted committers] is a key aspect of InnerSource.
+https://innersourcecommons.org/resources/learningpath/contributor/index[Contributors] on guest teams are upleveled so that they understand enough about the host team's project/repo to change it successfully.
 In the process of doing so, they come to better understand the host team's software system as a general consumer and ambassador for the project/software.
 This individual contributor can, over time and with experience, take on a broader role in the project as a trusted committer.
 

--- a/introduction/06-conclusion.asciidoc
+++ b/introduction/06-conclusion.asciidoc
@@ -3,7 +3,7 @@
 In this learning path, we've given an introduction to InnerSource.
 InnerSource applies open source best practices and principles to internal software development.
 It gives an additional option to consumers when producing teams are not able to deliver a needed feature request.
-Successful InnerSource involves a https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_product owner_] and https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_trusted committer_] from the *host team* as well as a https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributor_] from the *guest team*.
+Successful InnerSource involves a https://innersourcecommons.org/resources/learningpath/product-owner/index[_product owner_] and https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_trusted committer_] from the *host team* as well as a https://innersourcecommons.org/resources/learningpath/contributor/index[_contributor_] from the *guest team*.
 Done effectively, InnerSource brings many benefits to both participating teams.
 They key principles upon-which effective InnerSource works are *voluntary code contribution* and *prioritized mentorship*.
 

--- a/introduction/de/03-how-works.asciidoc
+++ b/introduction/de/03-how-works.asciidoc
@@ -20,9 +20,9 @@ Diese Konzepte rund um einen Besuch sind eine Metapher für Einstellung und Verh
 
 Werfen wir einen genaueren Blick darauf, wie der InnerSource-Prozess funktioniert.
 Bevor wir in das Thema tiefer einsteigen, schauen wir uns einige wichtige Rollen in den Gast- und Gastgeberteams an.
-Zunächst legt der https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_] fest, welche Funktionen das Hostteam als Beitrag zu akzeptieren bereit ist.
-Der https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributor_] ist die Person im Gastteam, die den Codebeitrag einreicht, welcher dann durch das Hostteam geprüft und ggf. akzeptiert wird.
-Der https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] steht dem Hostteam als zusätzliche Unterstützung für Review- und Mentoringaufgaben bei, um letztendlich den Contributor mit seinem Pullrequest zu unterstützen.
+Zunächst legt der https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_] fest, welche Funktionen das Hostteam als Beitrag zu akzeptieren bereit ist.
+Der https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributor_] ist die Person im Gastteam, die den Codebeitrag einreicht, welcher dann durch das Hostteam geprüft und ggf. akzeptiert wird.
+Der https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] steht dem Hostteam als zusätzliche Unterstützung für Review- und Mentoringaufgaben bei, um letztendlich den Contributor mit seinem Pullrequest zu unterstützen.
 Bei kleinen, einfacheren Projekten füllt oft eine einzelne Person _sowohl_ die Rolle des Product Owners als auch die des Trusted Committer aus.
 
 Basierend auf diesen Rollen können wir nun den InnerSource-Prozesses grob skizzieren.

--- a/introduction/de/04-benefits.asciidoc
+++ b/introduction/de/04-benefits.asciidoc
@@ -21,7 +21,7 @@ Neben der einfachen Verbesserung der Funktionalität die das Hostteam erzielen k
 Ein Hostteam kann mit größtem Aufwand Anforderungen für Ihr Produkt sammeln, wenn jedoch der Nutzer selbst die jeweilige Anforderung einreicht, sind die Chancen erheblich höher, dass die daraus resultierende Änderung genau auf die Bedürfnisse des Nutzers abgestimmt ist.
 Weiterhin gilt, während es möglicherweise nur ein einziges Gastteam die Änderung einreicht, ist dieses Team wahrscheinlich auch repräsentativ für andere Nutzer.
 
-Zusätzlich zu den oben aufgezeigten Vorteilen, bietet diese Art der Zusammenarbeit auch eine Chance zur Weiterbildung der https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[Contributors], während sie mit ihnen arbeiten und von ihnen als https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[Trusted Committers] lernen.
+Zusätzlich zu den oben aufgezeigten Vorteilen, bietet diese Art der Zusammenarbeit auch eine Chance zur Weiterbildung der https://innersourcecommons.org/resources/learningpath/contributor/index[Contributors], während sie mit ihnen arbeiten und von ihnen als https://innersourcecommons.org/resources/learningpath/trusted-committer/index[Trusted Committers] lernen.
 Diese Interaktionen helfen den Mitwirkenden in zu lernen und zu wachsen, was zu letztendlich zu einer *höheren Arbeitszufriedenheit* führt.
 Weiterhin wird im Allgemeinen die Projektdokumentation schrittweise verbessert, um Gastbeiträge in großem Maßstab zu ermöglichen und zu fördern.
 Natürlich ist auch nicht zu vergessen, dass sich die Mitwirkenden am Projekt des Hostteams beteiligt fühlen.

--- a/introduction/de/05-principles.asciidoc
+++ b/introduction/de/05-principles.asciidoc
@@ -45,8 +45,8 @@ Diese Kommunikation sollte auf eine Weise erfolgen, sodass die Information für 
 
 === Priorisierte Betreuung
 
-_Mentorship_ vom Hostteam zum Gastteam durch https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[Trusted Committers] ist ein Schlüsselaspekt von InnerSource.
-https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[Contributors] in Gastteams sind auf dem neuesten Stand, sodass sie genug über das Projekt / Repo des Host-Teams wissen um es erfolgreich verändern zu können.
+_Mentorship_ vom Hostteam zum Gastteam durch https://innersourcecommons.org/resources/learningpath/trusted-committer/index[Trusted Committers] ist ein Schlüsselaspekt von InnerSource.
+https://innersourcecommons.org/resources/learningpath/contributor/index[Contributors] in Gastteams sind auf dem neuesten Stand, sodass sie genug über das Projekt / Repo des Host-Teams wissen um es erfolgreich verändern zu können.
 Dabei lernen sie die Software des Hostteams sowohl als genereller Nutzer als auch als Botschafter für das Projekt / die Software besser verstehen.
 Diese einzelnen Mitarbeiter können im Laufe der Zeit und mit wachsender Erfahrung eine breitere Rolle im Projekt als Trusted Committer zu übernehmen.
 

--- a/introduction/de/06-conclusion.asciidoc
+++ b/introduction/de/06-conclusion.asciidoc
@@ -3,7 +3,7 @@
 In dieser Serie haben wir eine Einführung in InnerSource gegeben.
 InnerSource wendet Open Source Praktiken und Prinzipien auf die firmeninterne Softwareentwicklung an.
 Es bietet Nutzern eine zusätzliche Option, speziell wenn Produktionsteams nicht in der Lage sind, ein erforderliches Requirement im notwendigen Zeitraum zu liefern.
-Erfolgreiche InnerSource Projekte betreffen https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Produkt Owner_] und https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-Committer/01-Introduction.asciidoc [_Trusted Committer_] vom *Hostteam* sowie ein https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc [_Contributor_] vom *Gastteam*.
+Erfolgreiche InnerSource Projekte betreffen https://innersourcecommons.org/resources/learningpath/product-owner/index[_Produkt Owner_] und https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-Committer/01-Introduction.asciidoc [_Trusted Committer_] vom *Hostteam* sowie ein https://innersourcecommons.org/resources/learningpath/contributor/index [_Contributor_] vom *Gastteam*.
 Richtig betriebenes InnerSource bietet beiden teilnehmenden Teams viele Vorteile.
 Die Schlüsselprinzipien, nach denen gut geführte InnerSource Projekte funktionieren, sind *freiwilliger Code-Beitrag* und *Mentoring Fokus*.
 

--- a/introduction/zh/03-InnerSource如何运作.asciidoc
+++ b/introduction/zh/03-InnerSource如何运作.asciidoc
@@ -4,7 +4,7 @@
 
 在这个例子中，我们称团队A为 _调用团队(guest team)_ ，称团队B为 _维护团队(host team)_ 。 _协同_ 和 _主导_ 这两个术语暗示了一种类似于在家里接待客人的情况。在这种情况下，大多数人都想成为一个好主人。为了迎接协同方的到来，他们确保所有的东西都保持整洁。来访者在门口受到欢迎并被邀请进来。他们可以使用家中公共区域的功能和公用设施。可能会有一些客人被要求遵守的家规。同样的，大多数客人也想表现出对家庭和主人的尊重。他们对房子里的东西很小心，在他们逗留期间遵守规则。只要他们有礼貌，他们就会希望收到回访邀请。这些围绕着家访的概念是一个隐喻，它是团队在一个主导向另一个协同贡献代码库时应该采取的态度和行为。
 
-让我们仔细看看InnerSource的流程机制是如何工作的。为了帮助解释，我们将列出调用团队和维护团队中的几个关键人物。首先， https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_产品所有者 Product Owner_]  确定主人团队愿意接受哪些功能作为贡献。 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_贡献者 Contributor_] 是调用团队中提交代码贡献以供主人团队评审的个人。 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_受信任提交者 Trusted Committer_] 代表维护团队在提供一个成功的提拉请求所需的任何及时支持和指导。在小规模的基层工作中，一个人通常同时担任产所有者和受信任的提交者的角色。
+让我们仔细看看InnerSource的流程机制是如何工作的。为了帮助解释，我们将列出调用团队和维护团队中的几个关键人物。首先， https://innersourcecommons.org/resources/learningpath/product-owner/index[_产品所有者 Product Owner_]  确定主人团队愿意接受哪些功能作为贡献。 https://innersourcecommons.org/resources/learningpath/contributor/index[_贡献者 Contributor_] 是调用团队中提交代码贡献以供主人团队评审的个人。 https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_受信任提交者 Trusted Committer_] 代表维护团队在提供一个成功的提拉请求所需的任何及时支持和指导。在小规模的基层工作中，一个人通常同时担任产所有者和受信任的提交者的角色。
 
 有了这些定义，下面是一个InnerSource的贡献的基本概要。
 

--- a/introduction/zh/04-InnerSource的收益.asciidoc
+++ b/introduction/zh/04-InnerSource的收益.asciidoc
@@ -21,7 +21,7 @@ InnerSource允许工程时间在给定的时间内有机地流到组织需要它
 并使其优先级与所有使用者保持一致。维护团队可以对其生成的工作进行最佳的需求收集，
 但是当使用者本身提交工作时，结果更改与使用者的需求保持一致的几率要高得多。虽然可能只有一个调用团队提交更改，但该团队可能代表许多其他客户。
 
-除了这种联合之外，还有对 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[贡献者 contributor] 的一般培训和教育，因为他们与 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[受信任提交者 trusted committer] 一起工作并向他们学习。
+除了这种联合之外，还有对 https://innersourcecommons.org/resources/learningpath/contributor/index[贡献者 contributor] 的一般培训和教育，因为他们与 https://innersourcecommons.org/resources/learningpath/trusted-committer/index[受信任提交者 trusted committer] 一起工作并向他们学习。
 这种互动有助于贡献者在他们的职业生涯中学习和成长，从而获得 *更高的工作满意度* 。
 项目文档的改进使这些贡献能够规模化。贡献者认为维护团队项目是有利害关系的。
 这是他们向同事或新加入的团队推荐的东西。他们能够更好地理解项目，并能够向其他人回答关于项目的问题，从而减轻维护团队的一些负担。

--- a/introduction/zh/05-InnerSource的原则.asciidoc
+++ b/introduction/zh/05-InnerSource的原则.asciidoc
@@ -34,8 +34,8 @@
 这种沟通应该以一种容易被非核心团队成员查询和理解的方式进行。
 
 === 优先辅导
-通过 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[受信任提交者 trusted committers] ，从维护团队到调用团队的指导是InnerSource的一个关键方面。
-调用团队中的 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[贡献者 Contributors] 被提升，这样他们就足够了解维护团队的项目/仓库，从而能够成功地更改它。
+通过 https://innersourcecommons.org/resources/learningpath/trusted-committer/index[受信任提交者 trusted committers] ，从维护团队到调用团队的指导是InnerSource的一个关键方面。
+调用团队中的 https://innersourcecommons.org/resources/learningpath/contributor/index[贡献者 Contributors] 被提升，这样他们就足够了解维护团队的项目/仓库，从而能够成功地更改它。
 在这个过程中，他们作为项目/软件的一般用户和负责人，更好地理解了维护团队的软件系统。
 随着时间的推移和经验的积累，这个独立的贡献者可以在项目中扮演更广泛的角色，成为一个受信任提交者。
 

--- a/introduction/zh/06-结论.asciidoc
+++ b/introduction/zh/06-结论.asciidoc
@@ -2,8 +2,8 @@
 在这个学习过程中，我们已经介绍了InnerSource。
 InnerSource将开放源码的最佳实践和原则应用于内部软件开发。
 当维护团队(host team)无法交付所需的特性请求时，它为使用者提供了一个额外的选项。
-成功的InnerSource包括来自 *维护团队* 的 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_产品所有者 product owner_] 产品所有者和 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_受信任提交者 trusted committer_] ，
-以及来自 *调用团队(guest team)* 的 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_贡献者 contributor_] 。
+成功的InnerSource包括来自 *维护团队* 的 https://innersourcecommons.org/resources/learningpath/product-owner/index[_产品所有者 product owner_] 产品所有者和 https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_受信任提交者 trusted committer_] ，
+以及来自 *调用团队(guest team)* 的 https://innersourcecommons.org/resources/learningpath/contributor/index[_贡献者 contributor_] 。
 如果处理有效，InnerSource将为参与团队带来很多好处。有效的InnerSource可以带来 *自愿代码贡献* 和 *优先指导* 。
 
 虽然本培训包含了关于InnerSource的高级概述，但是在InnerSource真正为您的团队工作方面还有更多有用的细节。

--- a/product-owner/01-opening-article.asciidoc
+++ b/product-owner/01-opening-article.asciidoc
@@ -16,4 +16,4 @@ You can also get a copy of the booklet I wrote with O'Reilly there at http://inn
 
 Please watch the other videos first.
 See the links below.
-It helps to be familiar with the Agile or Lean processes, and it's really important that you understand the roles of the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committers_] and the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] before watching this video. Thank you.
+It helps to be familiar with the Agile or Lean processes, and it's really important that you understand the roles of the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committers_] and the https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] before watching this video. Thank you.

--- a/product-owner/03-major-benefits-are-built-into-the-innersource-process-article.asciidoc
+++ b/product-owner/03-major-benefits-are-built-into-the-innersource-process-article.asciidoc
@@ -3,7 +3,7 @@ Let me step through a few of those from a manager's perspective. I'll talk about
 
 First of that is _open code_.
 What do I mean by open code? Basically, the fact that the code is visible by all of the company, and there's a process for other developers to be able to submit pull requests on other code bases and get them accepted.
-To understand this more, please see the articles about https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committers_] and contributing agreements for more details.
+To understand this more, please see the articles about https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committers_] and contributing agreements for more details.
 
 Open code for a manager also means no more waiting or escalating to get bugs fixed or features implemented on other teams' code bases.
 You can start to implement and plan more effectively.

--- a/product-owner/04-new-roles-and-responsibilities-article.asciidoc
+++ b/product-owner/04-new-roles-and-responsibilities-article.asciidoc
@@ -1,14 +1,14 @@
 Being an InnerSource leader comes with new roles and responsibilities.
- One of the first one of those is supporting your TCs. TCs are the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committers_].
+ One of the first one of those is supporting your TCs. TCs are the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committers_].
 One of the first things that you're going to be doing is probably helping to choose who those new TCs are going to be and supporting them in their job.
-If you want to know more about what the TC role looks like, please review the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committer_] section.
+If you want to know more about what the TC role looks like, please review the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] section.
 
 They are the gatekeepers to your code base.
 Typically, they are lead developers who are good at code reviews and have a deep understanding of the code base's architecture.
 They will need your support.
 They will also be key for you in regards to collaborating with other teams.
 They'll be your right-hand people in regards to estimations and integrations. Remember to support them.
-They have some crazy new responsibilities and may need mentoring to help with those https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributing teams_].
+They have some crazy new responsibilities and may need mentoring to help with those https://innersourcecommons.org/resources/learningpath/contributor/index[_contributing teams_].
 Developers are not often taught how to negotiate.
 I recommend the book https://www.amazon.com/Getting-Yes-Negotiating-Agreement-Without/dp/0143118757/[Getting to Yes], and for you to use it with them.
 
@@ -25,9 +25,9 @@ So nowadays, you document it so that the guests know that hey, in the shower, th
 Thirdly, documentation time.
 At the beginning, you may have to sink a fair amount of your time in regards to the open documentation, and going beyond just your open roadmaps and other open processes.
 I'm also talking about things like UX and UI standards, API standards, or even testing requirements.
-With that, of course, you're going to want to sync up with your https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committers_] as to what they need to feel safe in regards to some of their coding requirements. It'll be worth it, promise.
+With that, of course, you're going to want to sync up with your https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committers_] as to what they need to feel safe in regards to some of their coding requirements. It'll be worth it, promise.
 
-Once you start working with those other teams, and when you onboard new developers and get so much more done than you'd gotten previously, remember those https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_new developers_] - you can also get them to help you write some of this brand-new documentation.
+Once you start working with those other teams, and when you onboard new developers and get so much more done than you'd gotten previously, remember those https://innersourcecommons.org/resources/learningpath/contributor/index[_new developers_] - you can also get them to help you write some of this brand-new documentation.
 If your tool is one of those bottlenecks and is really important to them, they may even offer to help you do a lot of the heavy lifting in regards to the standards, because they want to integrate in with your product.
 
 Lastly, internal marketing.

--- a/product-owner/05-recap-takeaways-article.asciidoc
+++ b/product-owner/05-recap-takeaways-article.asciidoc
@@ -10,7 +10,7 @@ Also, you get to collaborate more with your peers to accomplish more with less, 
 The open processes also means that you get more credit for your work than you were probably getting previously.
 By going through and publishing those planning processes, it also means that you can deal with less politics, because everything becomes so much more clear.
 
-And lastly, you've got those new roles and responsibilities, such as supporting your new https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc[_Trusted Committers_].
+And lastly, you've got those new roles and responsibilities, such as supporting your new https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committers_].
 They're really going to need your help.
 Also, working with those other product owners so that you can both get more of your work done in a faster time frame.
 Going to have to sink a lot of time in regards to the new documentation, but that's OK, because you're going to get more credit for it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+## substitute_article_urls.js
+
+A node script to replace all Learning Path article links with urls for a particular platform, using [urls.yaml](../config/urls.yaml).
+
+### Usage:
+```
+npm ci
+node substitute_article_urls.js $TARGET
+```
+For example, to point all links to innersourcecommons.org:
+```
+node substitute_article_urls.js isc
+```

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+    }
+  }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "scripts",
+  "version": "1.0.0",
+  "description": "",
+  "main": "substitute_article_urls.js",
+  "dependencies": {
+    "yaml": "^1.10.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/scripts/substitute_article_urls.js
+++ b/scripts/substitute_article_urls.js
@@ -1,0 +1,45 @@
+const fs = require('fs')
+const YAML = require('yaml')
+
+const target = process.argv[2]
+
+const urlsFile = fs.readFileSync('../config/urls.yaml', 'utf8')
+const urls = YAML.parse(urlsFile).map(({ video, article }) => [video, article]).flat()
+
+const getArticleFiles = (path) => {
+  return fs.readdirSync(path).map((filename) => {
+    const filePath = `${path}/${filename}`
+    if (fs.lstatSync(filePath).isDirectory()) {
+      return getArticleFiles(filePath)
+    } else {
+      return {
+        filePath,
+        asciiDoc: fs.readFileSync(filePath, 'utf-8')
+      }
+    }
+  }).flat()
+}
+const articleFiles = [getArticleFiles('../introduction'), getArticleFiles('../product-owner'), getArticleFiles('../trusted-committer'), getArticleFiles('../contributor')].flat()
+
+const substituted = articleFiles.map((articleFile) => {
+  let asciiDoc = articleFile.asciiDoc
+
+  urls.forEach((urlObj) => {
+    const targetUrl = urlObj[target]
+    if (targetUrl) {
+      Object.keys(urlObj).forEach((platform) => {
+        const url = urlObj[platform]
+        if (url && platform !== target) {
+          asciiDoc = asciiDoc.split(url).join(targetUrl)
+        }
+      })
+    }
+  })
+
+  return {
+    filePath: articleFile.filePath,
+    asciiDoc
+  }
+})
+
+substituted.forEach(substitutedArticle => fs.writeFileSync(substitutedArticle.filePath, substitutedArticle.asciiDoc))

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -20,7 +20,7 @@ dimensions in the following sections.
 Before we go into the details of what a Trusted Committer actually does, let’s spend
 some time contrasting the Trusted Committer role with other roles in InnerSource at a
 high level of abstraction and explain why we think the name is both apt
-and important. Let’s start with the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributor_] role. A
+and important. Let’s start with the https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributor_] role. A
 _Contributor_ — as the name implies—makes contributions to an InnerSource
 community. These contributions could be code or non-code artifacts, such
 as bug reports, feature requests, or documentation.
@@ -40,7 +40,7 @@ responsibility to push code closer to production and are generally
 allowed to perform tasks that have a higher level of risk associated
 with them.
 
-The https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_ (PO)] is the third role in InnerSource. Similar to
+The https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_ (PO)] is the third role in InnerSource. Similar to
 agile processes, the PO is responsible for defining and prioritizing
 requirements and stories for the community to implement. The PO
 interacts often with the Trusted Committer, (e.g., in making sure that a requested or
@@ -75,10 +75,10 @@ a quick look at the responsibilities of a Trusted Committer.
 
 Trusted Committers have various responsibilities, including:
 
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/02-ensuring-product-quality.asciidoc[Ensuring product quality]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/03-keeping-the-community-healthy.asciidoc[Keeping the community healthy]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc[Reducing the barriers to making contributions]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/04-uplevelling-community-members.asciidoc[Upleveling the community]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc[Advocating the community's needs]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/02/[Ensuring product quality]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/03/[Keeping the community healthy]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/05/[Reducing the barriers to making contributions]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/04/[Upleveling the community]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/06/[Advocating the community's needs]
 
-We will look at these responsibilities in more depth in the following pages and also explore the path of https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/07-becoming-a-trusted-committer.asciidoc[becoming a Trusted Committer] at the end of this article.
+We will look at these responsibilities in more depth in the following pages and also explore the path of https://innersourcecommons.org/resources/learningpath/trusted-committer/07/[becoming a Trusted Committer] at the end of this article.

--- a/trusted-committer/01-introduction.asciidoc
+++ b/trusted-committer/01-introduction.asciidoc
@@ -5,7 +5,7 @@ The Trusted Committer (TC) role is one of the key roles in an
 InnerSource community. Think of Trusted Committers as the people in a community that
 you trust with important technical decisions and with mentoring
 contributors to ultimately get contributions over the finish line.
-The Trusted Committer role is both demanding and rewarding. It is 
+The Trusted Committer role is both demanding and rewarding. It is
 more than just being an opinionated gatekeeper and is instrumental for
 the success of any InnerSource community.
 
@@ -13,7 +13,7 @@ Generally speaking, the Trusted Committer role is defined by its responsibilitie
 rather than by its privileges. On a very high level, Trusted Committers represent the
 interests of both their InnerSource community and the products the
 community is building. They are concerned with the health of both the
-community and the product. So as a Trusted Committer, you’ll have both 
+community and the product. So as a Trusted Committer, you’ll have both
 tech- and community-oriented responsibilities. We’ll explore both of these
 dimensions in the following sections.
 
@@ -46,17 +46,17 @@ requirements and stories for the community to implement. The PO
 interacts often with the Trusted Committer, (e.g., in making sure that a requested or
 contributed feature actually belongs to the product). Especially in
 smaller, grassroots InnerSource communities, the Trusted Committer usually also
-acts as a PO. Check out our https://learning.oreilly.com/videos/innersource-product-owners/9781492046707[Product Owner Learning Path segment]
+acts as a PO. Check out our https://innersourcecommons.org/resources/learningpath/product-owner/index[Product Owner Learning Path segment]
 for more detailed information.
 
 === Why Role Names Matter
 
 The role of the Trusted Committer is present in every successful InnerSource community
 but not every community uses that name. Some communities use the term
-Maintainer, but this term conflicts with other technical roles such as the 
+Maintainer, but this term conflicts with other technical roles such as the
 "Maintainer" role defined by GitHub, for instance. Apache uses the term
 _Committer_, too, but they attach fewer and mostly tech-oriented
-responsibilities to that role. With its additional community-oriented responsibilities, 
+responsibilities to that role. With its additional community-oriented responsibilities,
 the Trusted Committer role goes beyond that. The "Trusted" in Trusted Committer
 means this person is trusted and thus empowered by both their
 management and their community to do their job. By fostering openness
@@ -67,8 +67,8 @@ Similar to how naming is important in writing software, choosing the right names
 doing so consistently ensures that everyone has the same understanding about the roles played in the community.
 
 Now that you have a basic understanding of the role, why using the
-term Trusted Committer is appropriate, and know how a Trusted Committer 
-might interact with other common roles in a software project, let's take 
+term Trusted Committer is appropriate, and know how a Trusted Committer
+might interact with other common roles in a software project, let's take
 a quick look at the responsibilities of a Trusted Committer.
 
 === Responsibilities

--- a/trusted-committer/02-ensuring-product-quality.asciidoc
+++ b/trusted-committer/02-ensuring-product-quality.asciidoc
@@ -12,7 +12,7 @@ tech-related decisions themselves or do all the work to implement them.
 
 It is the Trusted Committer's job to communicate and clarify quality standards in their
 community and to formulate them in a way that is understandable and
-actionable by their https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_]. This includes written documentation,
+actionable by their https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_]. This includes written documentation,
 of course, but the most effective way for Trusted Committers to communicate these quality standards is by example. We think it
 can be a worthwhile goal for an InnerSource community to try and
 distinguish itself from traditional software development projects not
@@ -26,7 +26,7 @@ performed as part of pull requests (PRs), is most frequently used to ensure qual
 and participate in pull requests by pointing out necessary improvements,
 it is usually only the Trusted Committer who can ultimately accept and merge or reject
 a contribution. This is what we meant earlier when we said "Trusted Committers can push code
-closer to production." Trusted Committers should also help https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] during
+closer to production." Trusted Committers should also help https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] during
 a PR to get their contributions over the finish line.
 
 That said, it is ultimately the contributor's job to make that happen.
@@ -34,14 +34,14 @@ The job of a Trusted Committer is not to accept all contributions by default, bu
 only accept those that meet the defined criteria in terms of quality and
 scope. And Trusted Committers should avoid rewriting a contributor's code to make it
 "fit" as much as possible, even if it means spending more time
-supporting  https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] in a PR. Trusted Committers
+supporting  https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] in a PR. Trusted Committers
 take a long-term perspective and understand that this kind of support is
 an investment in the longevity of the community, and it will increase the community's development speed in the long run.
 
 Sometimes project requirements or limitations are not known upfront and are instead
 discovered during development. Trusted Committers are also responsible for making sure
-these findings are captured and documented for both the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owners_] and the
-https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_].
+these findings are captured and documented for both the https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owners_] and the
+https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_].
 
 But the Trusted Committer's purview with respect to quality goes beyond pull requests. 
 Trusted Committers think about quality on a strategic level and ensure the
@@ -56,10 +56,10 @@ The effectiveness of the Trusted Committer is strongly related to code health.
 Absent the latter, Trusted Committers will have to spend much of their valuable time
 validating and documenting workarounds for bugs or a fragile
 architecture and will not have enough time to spend on onboarding and
-mentoring https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_].
+mentoring https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_].
 
 In conclusion, ensuring product quality is a key responsibility of Trusted Committers.
 They set quality standards and lead by example. They participate in pull
-requests and help https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] meet
+requests and help https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] meet
 quality standards. They also take responsibility for the long-term
 health of the software.

--- a/trusted-committer/03-keeping-the-community-healthy.asciidoc
+++ b/trusted-committer/03-keeping-the-community-healthy.asciidoc
@@ -7,10 +7,10 @@ strive to keep the community building the software healthy
 as well. Because of that, they must strike a good balance between ensuring product quality and growing a healthy community.
 
 What does a healthy community look like? Quite simply, in a healthy community,
-https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] tend to stick around, can spend most of their time developing software, and are able to level up their abilities.
+https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] tend to stick around, can spend most of their time developing software, and are able to level up their abilities.
 As a result, a healthy community will be continually growing.
 
-Why do https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] join and stick around in a community? Some do because they
+Why do https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] join and stick around in a community? Some do because they
 subscribe to the purpose or the mission of the community. It is the Trusted Committer's job to
 clearly articulate and promote this purpose. The importance of this is often
 not recognized, but marketing a community and its products is truly essential.
@@ -44,13 +44,13 @@ development projects.
 We believe that Trusted Committers should prioritize onboarding and mentoring during pull
 requests over reaching communicated release dates, unless there is a very
 good reason not to. Good mentoring during pull requests leads to a higher level
-of trust and engagement by https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_], which in turn leads
-to more contributions. We’ll discuss this more in https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/04-uplevelling-community-members.asciidoc["Upleveling the Community"].
+of trust and engagement by https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_], which in turn leads
+to more contributions. We’ll discuss this more in https://innersourcecommons.org/resources/learningpath/trusted-committer/04/["Upleveling the Community"].
 
 Finally, some people stick around in InnerSource communities because
 they get to focus on developing software instead of activities considered overhead or waste, especially 
 common in large companies with a strong focus on processes. The Trusted Committer's job in this context is to
-ensure that https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] can actually focus on their projects by
+ensure that https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] can actually focus on their projects by
 communicating and enacting helpful contribution guidelines.
 
 One important aspect of these guidelines is to explain what we call _signaling_ in
@@ -65,10 +65,10 @@ them as a community as much as possible.
 For Trusted Committers to be able to fulfill all these responsibilities, it is
 important that they communicate regularly with community members and
 keep an ear to the ground.  We'll
-go into more detail about this in the section in https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc["Advocating the Community's
+go into more detail about this in the section in https://innersourcecommons.org/resources/learningpath/trusted-committer/06/["Advocating the Community's
 Needs"].
 
 In summary, Trusted Committers should strive to create a welcoming and appreciative
-environment for their https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] that allows them to concentrate on writing
+environment for their https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] that allows them to concentrate on writing
 software and growing personally by creating opportunities to learn from other
 community members.

--- a/trusted-committer/04-uplevelling-community-members.asciidoc
+++ b/trusted-committer/04-uplevelling-community-members.asciidoc
@@ -3,7 +3,7 @@
 == Upleveling Community Members
 
 There is a continuum of participation in an InnerSource community. 
-There are people who are not aware of the community. _Newcomers_ might be interested in the community and its product, but have not yet used it. _Consumers_ use the software but may not have made a contribution. Then there are the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] who have made at least one contribution, and finally the _Trusted Committers_, who are taking responsibility for both the software and the community.
+There are people who are not aware of the community. _Newcomers_ might be interested in the community and its product, but have not yet used it. _Consumers_ use the software but may not have made a contribution. Then there are the https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] who have made at least one contribution, and finally the _Trusted Committers_, who are taking responsibility for both the software and the community.
 As a Trusted Committer, you are responsible for moving individuals along this continuum
 and upleveling their ability to make contributions. In this sense, Trusted Committers
 act as force multipliers in their community.
@@ -12,27 +12,27 @@ It is important for Trusted Committers to market their
 product and communities to increase the number of
 newcomers and consumers. They should also communicate opportunities to
 make contributions to consumers and try to elicit and align the
-interests of potential https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] with that of the community. What
-often works well is if https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] are able to work on something that
+interests of potential https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] with that of the community. What
+often works well is if https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] are able to work on something that
 benefits their department or role in the company. Development tools and automation are good examples.
 
-Finally, it is the Trusted Committer's responsibility to identify and support https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] with the potential to grow 
+Finally, it is the Trusted Committer's responsibility to identify and support https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] with the potential to grow 
 by encouraging them to tackle challenging tasks and mentor them towards completion. This is, in our opinion, a Trusted Committer's
 noblest responsibility, and it is rewarding for both Trusted Committer and
 contributor. We've heard Trusted Committers say that mentoring and
 seeing people level up their abilities more than makes up for the fact
 that they have less time to actually spend writing software.
 
-As mentioned in the https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/03-keeping-the-community-healthy.asciidoc[previous section], learning and personal growth are
+As mentioned in the https://innersourcecommons.org/resources/learningpath/trusted-committer/03/[previous section], learning and personal growth are
 reasons people join and stick around in an InnerSource community.
-Upleveling their https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] is one of the most powerful tools Trusted Committers have
+Upleveling their https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] is one of the most powerful tools Trusted Committers have
 at their disposal to increase the speed, output and longevity of their
 communities. It is also one of the key arguments with which to convince
 management to allow their employees to participate in an InnerSource
 community, as that will make their employees more valuable to 
 the company overall and help them retain top talent.
 
-In summary, Trusted Committers need to attract new https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] and level up their
+In summary, Trusted Committers need to attract new https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] and level up their
 ability to make contributions. This activity ultimately levels up the
 community’s ability to create better software faster. They do so by
 communicating opportunities to make contributions and by helping and

--- a/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc
+++ b/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc
@@ -2,14 +2,14 @@
 
 Soliciting contributions in an InnerSource community is more challenging than it is in an Open Source community for a number of reasons:
 
-* The sheer number of potential https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] is lower in InnerSource communities.
+* The sheer number of potential https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] is lower in InnerSource communities.
 * Contributors will want to contribute during their work time, which means they are more time constrained.
 * Work in InnerSource might not necessarily be part of Contributors' official
 performance goals, so time spent working on InnerSource
 may seem to detract from achieving those goals.
 
 That's why it's important for Trusted Committers to make the processes for making
-contributions and onboarding https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] as frictionless as
+contributions and onboarding https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] as frictionless as
 possible. There are a number of things that can help:
 
 * Have a good README.md in each code repository. A good README.md
@@ -18,7 +18,7 @@ addition, it should provide detailed instructions on how to get, build,
 test, and use the software in the repository, including information about
 the license.
 * Have a good CONTRIBUTING.md that outlines what is expected of the
-https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributor_]. It should answer
+https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributor_]. It should answer
 common questions, such as:
 ** How do I submit a bug report or feature request?
 ** Who and how do I contact if I have questions?
@@ -37,19 +37,19 @@ obligations in layman’s terms.
 
 In addition to these documentary tasks, similar to Open Source
 software development it should be easy and straightforward to run and test the software
-being developed locally by potential https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_], so they can start implementing and validating their contribution with as little effort as
+being developed locally by potential https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_], so they can start implementing and validating their contribution with as little effort as
 possible.
 
 There are two common models for making contributions:
 _shared repository_ and _fork and join_. Both have advantages, and as a Trusted Committer,
 you want to support both models to accommodate different needs of your
-potential and current https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_].
+potential and current https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_].
 Your Contributors will often have questions about the contribution process or about the community itself, and someone has to be available to answer these questions. 
 It is therefore important for any InnerSource community to
 have one or more contact persons that are available for answering such
 questions. Someone from the group of Trusted Committers is usually that contact person, or else they need to make sure there is a community member "on call".
 
-It is also important to help potential https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_] determine what
+It is also important to help potential https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_] determine what
 contributions are needed. These can be code contributions but
 also noncode contributions, such as writing documentation, creating
 artwork, or organizing events. One common way to do this is to tag

--- a/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc
+++ b/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc
@@ -21,7 +21,7 @@ well community related risks to management. At the same time, Trusted Committers
 strategic and work within the degrees of freedom afforded by their companies.
 
 Related to this, Trusted Committers need to make sure that the community and individual
-https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributors_] get public credit for their work, to make sure everyone is aware
+https://innersourcecommons.org/resources/learningpath/contributor/index[_contributors_] get public credit for their work, to make sure everyone is aware
 of the valuable contribution made. Public credit is kind of the currency in which
 contributors are being paid, especially those who contribute voluntarily. It is
 good practice to commend valuable contributors publicly and making sure their
@@ -35,7 +35,7 @@ good Trusted Committer will engage with management and advocate the need for
 public credit in this case. Failure to give credit is almost never done in bad
 faith, though, and Trusted Committers should be able to easily correct that.
 
-Another common example where the Trusted Committer's advocacy is needed is when https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributors_]
+Another common example where the Trusted Committer's advocacy is needed is when https://innersourcecommons.org/resources/learningpath/contributor/index[_contributors_]
 are not given time or permission to make a contribution.  This situation can can happen if
 the community is not working on a product that belongs to the domain of the contributor's
 department and thus not relevant for the respective manager's goals.
@@ -43,7 +43,7 @@ In this case, the Trusted Committer should engage in discussion with the contrib
 and lobby for an alternative decision.
 
 In summary, there are many situations in which Trusted Committers need to advocate the
-interests of individual https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributors_] and their community as a whole to the
+interests of individual https://innersourcecommons.org/resources/learningpath/contributor/index[_contributors_] and their community as a whole to the
 organization. They do this because they understand that the value that the
 community can provide to the organization depends on the health and longevity
 of the community and ultimately on a trustworthy relationship between both.

--- a/trusted-committer/07-becoming-a-trusted-committer.asciidoc
+++ b/trusted-committer/07-becoming-a-trusted-committer.asciidoc
@@ -16,11 +16,11 @@ The process of officially becoming a Trusted Committer differs from community to
 depends on where you are in your InnerSource journey and might evolve over
 time. In grass-roots type communities, the founders often automatically assume
 the role of the Trusted Committer as well. As a community grows, the community or the
-existing Trusted Committers might nominate a https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributor_] to become Trusted Committer, which might or might
+existing Trusted Committers might nominate a https://innersourcecommons.org/resources/learningpath/contributor/index[_contributor_] to become Trusted Committer, which might or might
 not be subject to a community vote. Ideally, nominated contributors should take
 on the Trusted Committer role voluntarily, as that indicates a high level of commitment.
 
-What are the criteria to apply in nominating https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributors_] for a Trusted Committer role? What
+What are the criteria to apply in nominating https://innersourcecommons.org/resources/learningpath/contributor/index[_contributors_] for a Trusted Committer role? What
 does it take to successfully fill the role of a Trusted Committer? First off, potential Trusted Committers
 need to have demonstrated a deep, technical competence during their work in the
 community. In addition to that, they must have proven their ability to
@@ -35,7 +35,7 @@ able to deal with stressful social situations, which are bound to come up from
 time to time. Contributors who satisfy these criteria will be good potential
 Trusted Committers, in our opinion.
 
-For some https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_contributors_], the Trusted Committer role might not appear all that attractive as it
+For some https://innersourcecommons.org/resources/learningpath/contributor/index[_contributors_], the Trusted Committer role might not appear all that attractive as it
 means spending less time on coding. Being nominated as a Trusted Committer might even be
 perceived by some as a demotion or a negative comment on their coding skills.
 The opposite is true. Being nominated as a Trusted Committer is most often a sign that someone

--- a/trusted-committer/de/01-introduction.asciidoc
+++ b/trusted-committer/de/01-introduction.asciidoc
@@ -14,7 +14,7 @@ Wir werden uns die beiden Dimensionen in den folgenden Abschnitten genauer ansch
 
 Bevor wir aber in die Details gehen, was die eigentliche Aufgabe eines _Trusted Committers_ ist, wollen wir uns zunächst auf höherer Abtraktionsebene anschauen, 
 wie sich die Rolle des _Trusted Committers_ von den anderen Rollen in der _InnerSource_ unterscheidet und dabei erklären, warum wir glauben, dass die 
-Bezeichnung sowohl  passend als auch wichtig ist. Lasst uns beginnen mit der Rolle des https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[_Contributors_]. Ein 
+Bezeichnung sowohl  passend als auch wichtig ist. Lasst uns beginnen mit der Rolle des https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_]. Ein 
 _Contributor_ — wie schon der Name nahelegt — liefert Beiträge zu einer _InnerSource_-Organisationseinheit.
  Diese Beiträge können entweder _code_ oder andere Artefakte wie z.B. Fehlerreports, Änderungsanforderungen oder Dokumentation sein.  
 
@@ -27,7 +27,7 @@ _Trusted Committer_ sowohl für den Bau eines Hauses als auch für die Hausordnu
  miteinander arbeiten können. Verglichen mit den _Contributors_ haben _Trusted Committers_ sich die Verantwortlichkeit verdient, näher am produktiven Code zu
 arbeiten und sind grundsätzlich befugt, Aufgaben auszuführen, die mit einem höheren Riskio verbunden sind.
 
-Der https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc[_Product Owner_ (PO)] ist die dritte 
+Der https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_ (PO)] ist die dritte 
 Rolle bei _InnerSource_. Ähnlich wie bei agilen Prozessen ist der _PO_ verantwortlich für die Definition und Priorisierung von Anforderungen und User Stories,
 welche die jeweilige Organisationseinheit umsetzen soll. Der _PO_ arbeitet eng mit dem _Trusted Committer_ zusammen, z.B. um sicherzustellen, dass ein angefordertes oder bereitgestelltes Feature
  tatsächlich Bestandteil des Produkts sein soll. Speziell in kleineren _InnerSource_-Organisationen kann der _Trusted Committer_ meistens auch die Aufgaben des 
@@ -57,12 +57,12 @@ kurzen Blick auf die Verantwortlichkeiten eines _Trusted Committers_ werfen.
 
 _Trusted Committers_ haben verschiedene Verantwortlichkeiten, unter anderem:
 
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/02-ensuring-product-quality.asciidoc[Ensuring product quality]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/03-keeping-the-community-healthy.asciidoc[Keeping the community healthy]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc[Reducing the barriers to making contributions]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/04-uplevelling-community-members.asciidoc[Upleveling the community]
-* https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc[Advocating the community's needs]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/02/[Ensuring product quality]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/03/[Keeping the community healthy]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/05/[Reducing the barriers to making contributions]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/04/[Upleveling the community]
+* https://innersourcecommons.org/resources/learningpath/trusted-committer/06/[Advocating the community's needs]
 
-Wir werden diese Verantwortlichkeiten in den folgenden Kapiteln weiter vertiefen, bitte schau Dir dazu auch das Kapitel https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/07-becoming-a-trusted-committer.asciidoc[07 becoming a Trusted Committer] am Ende an.
+Wir werden diese Verantwortlichkeiten in den folgenden Kapiteln weiter vertiefen, bitte schau Dir dazu auch das Kapitel https://innersourcecommons.org/resources/learningpath/trusted-committer/07/[07 becoming a Trusted Committer] am Ende an.
 [role="pagenumrestart"]
 

--- a/trusted-committer/de/01-introduction.asciidoc
+++ b/trusted-committer/de/01-introduction.asciidoc
@@ -3,44 +3,44 @@
 
 Die Rolle des _Trusted Committers_ (TC) ist eine der Schlüsselrollen einer
 _InnerSource_-Organisation. Stell Dir einen _Trusted Committer_ als jemanden im Team vor, auf den Du bei wichtigen technischen Entscheidungen
- vertraust, und als einen fähigen Betreuer, der dem _Committer_ hilft, dessen Beitrage zielführend in das Produkt integrieren zu können. Die Rolle eines _Trusted Committers_ 
+ vertraust, und als einen fähigen Betreuer, der dem _Committer_ hilft, dessen Beitrage zielführend in das Produkt integrieren zu können. Die Rolle eines _Trusted Committers_
 ist sowohl anspruchsvoll als auch wertgeschätzt. Sie ist mehr als nur ein bürokratischer Pförtner, im Gegenteil, sie ist maßgeblich für den Erfolg jeder _InnerSource_ Organisation.
 
-Allgemein gesagt ist die Rolle des _Trusted Committers_ mehr durch ihre Verantwortlichkeiten als durch ihre Rechte definiert. 
-Auf einer höheren Ebene repräsentieren die _Trusted Committers_ sowohl die Interessen der _InnerSource_ Organisationseinheit als auch die der Produkte, 
+Allgemein gesagt ist die Rolle des _Trusted Committers_ mehr durch ihre Verantwortlichkeiten als durch ihre Rechte definiert.
+Auf einer höheren Ebene repräsentieren die _Trusted Committers_ sowohl die Interessen der _InnerSource_ Organisationseinheit als auch die der Produkte,
 welche von der entsprechenden Organisationseinheit entwickelt werden. _Trusted Committers_ kümmern sich gleichermaßen um eine funktionierende Organisation und ein technisch einwandfreies Produkt.
- Daher umfasst die Rolle sowohl technik- als auch teamorientierte Verantwortlichkeiten. 
+ Daher umfasst die Rolle sowohl technik- als auch teamorientierte Verantwortlichkeiten.
 Wir werden uns die beiden Dimensionen in den folgenden Abschnitten genauer anschauen.
 
-Bevor wir aber in die Details gehen, was die eigentliche Aufgabe eines _Trusted Committers_ ist, wollen wir uns zunächst auf höherer Abtraktionsebene anschauen, 
-wie sich die Rolle des _Trusted Committers_ von den anderen Rollen in der _InnerSource_ unterscheidet und dabei erklären, warum wir glauben, dass die 
-Bezeichnung sowohl  passend als auch wichtig ist. Lasst uns beginnen mit der Rolle des https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_]. Ein 
+Bevor wir aber in die Details gehen, was die eigentliche Aufgabe eines _Trusted Committers_ ist, wollen wir uns zunächst auf höherer Abtraktionsebene anschauen,
+wie sich die Rolle des _Trusted Committers_ von den anderen Rollen in der _InnerSource_ unterscheidet und dabei erklären, warum wir glauben, dass die
+Bezeichnung sowohl  passend als auch wichtig ist. Lasst uns beginnen mit der Rolle des https://innersourcecommons.org/resources/learningpath/contributor/index[_Contributors_]. Ein
 _Contributor_ — wie schon der Name nahelegt — liefert Beiträge zu einer _InnerSource_-Organisationseinheit.
- Diese Beiträge können entweder _code_ oder andere Artefakte wie z.B. Fehlerreports, Änderungsanforderungen oder Dokumentation sein.  
+ Diese Beiträge können entweder _code_ oder andere Artefakte wie z.B. Fehlerreports, Änderungsanforderungen oder Dokumentation sein.
 
-_Contributors_ können, müssen aber nicht Teil der Organisation sein, zu der sie Beiträge liefern. Sie können z.B. von einem anderem Team beauftragt werden, ein Feature zu entwickeln, 
+_Contributors_ können, müssen aber nicht Teil der Organisation sein, zu der sie Beiträge liefern. Sie können z.B. von einem anderem Team beauftragt werden, ein Feature zu entwickeln,
 welches das Team benötigt. Deshalb sprechen wir im Fall von _Contributors_ manchmal auch von _Guests_ oder Teilen eines _Guest_Teams_. Der _Contributor_ ist
- verantwortlich dafür, dass er sich anpasst und die Erwartungen und Regeln der jeweiligen Organisationseinheit, zu der einen Beitrag liefert, erfüllt und respektiert. 
+ verantwortlich dafür, dass er sich anpasst und die Erwartungen und Regeln der jeweiligen Organisationseinheit, zu der einen Beitrag liefert, erfüllt und respektiert.
 
-Der _Trusted Committer_ ist immer ein Mitglied der _InnerSource_-Organisationseinheit (manchmal auch _Host Team_ genannt). In diesem Vergleich wäre der 
+Der _Trusted Committer_ ist immer ein Mitglied der _InnerSource_-Organisationseinheit (manchmal auch _Host Team_ genannt). In diesem Vergleich wäre der
 _Trusted Committer_ sowohl für den Bau eines Hauses als auch für die Hausordnung verantwortlich, in deren Umgebung die Gäste sich wohlfühlen und effektiv
  miteinander arbeiten können. Verglichen mit den _Contributors_ haben _Trusted Committers_ sich die Verantwortlichkeit verdient, näher am produktiven Code zu
 arbeiten und sind grundsätzlich befugt, Aufgaben auszuführen, die mit einem höheren Riskio verbunden sind.
 
-Der https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_ (PO)] ist die dritte 
+Der https://innersourcecommons.org/resources/learningpath/product-owner/index[_Product Owner_ (PO)] ist die dritte
 Rolle bei _InnerSource_. Ähnlich wie bei agilen Prozessen ist der _PO_ verantwortlich für die Definition und Priorisierung von Anforderungen und User Stories,
 welche die jeweilige Organisationseinheit umsetzen soll. Der _PO_ arbeitet eng mit dem _Trusted Committer_ zusammen, z.B. um sicherzustellen, dass ein angefordertes oder bereitgestelltes Feature
- tatsächlich Bestandteil des Produkts sein soll. Speziell in kleineren _InnerSource_-Organisationen kann der _Trusted Committer_ meistens auch die Aufgaben des 
-PO wahrnehmen. Schau Dir für weiterführende Informationen unser https://learning.oreilly.com/videos/innersource-product-owners/9781492046707[Product Owner Learning Path segment]
+ tatsächlich Bestandteil des Produkts sein soll. Speziell in kleineren _InnerSource_-Organisationen kann der _Trusted Committer_ meistens auch die Aufgaben des
+PO wahrnehmen. Schau Dir für weiterführende Informationen unser https://innersourcecommons.org/resources/learningpath/product-owner/index[Product Owner Learning Path segment]
 an.
 
 === Warum Rollennamen von Bedeutung sind
 
-Man findet die Rolle des _Trusted Committers_  in jeder erfolgreichen _InnerSource_-Organisation, wenngleich die Rolle nicht in jeder Organisation so genannt 
+Man findet die Rolle des _Trusted Committers_  in jeder erfolgreichen _InnerSource_-Organisation, wenngleich die Rolle nicht in jeder Organisation so genannt
 wird.
-Manche Organisationen benutzen den Begriff _Maintainer_, aber diese Bezeichnung überschneidet sich mit anderen technischen Rollen, wie zum Beispiel 
+Manche Organisationen benutzen den Begriff _Maintainer_, aber diese Bezeichnung überschneidet sich mit anderen technischen Rollen, wie zum Beispiel
 die in _GitHub_ definierte Role des "Maintainers". Auch Apache nutzt den Begriff des
-_Committers_, aber dort wird die Rolle mit weniger und meist technisch orientierten Verantwortlichkeiten verbunden. 
+_Committers_, aber dort wird die Rolle mit weniger und meist technisch orientierten Verantwortlichkeiten verbunden.
 Durch die zusätzlichen auf die Organisation bezogenen Verantwortlichkeiten geht die hier definierte Rolle des _Trusted Committer_ weit darüber hinaus.
 Der Begriff "Trusted" in _Trusted Committer_ bezieht sich auf das Vertrauen, das von der Organisation in diese Person gesetzt wird und das aus diesem heraus
 sowohl vom Management als auch der Arbeitsebene getragenen Mandat, die übertragenen Aufgaben zu erfüllen. Durch Förderung von Offenheit und Transparenz schaffen
@@ -49,8 +49,8 @@ _Trusted Committers_ Vertrauen in den Prozess und ebenso in das entwickelte Prod
 So, wie in der Softwarentwicklung Namenskonventionen wichtig sind, stellen eindeutige Namen für Rollen sicher, dass überall ein gleiches Verständnis darüber
 herrscht, welche Aufgaben die jeweilige Rolle in einer Organisationseinheit wahrnimmt.
 
-Nachdem Du nun ein grundsätzliches Verständnis von der Rolle hast, wieso der Begriff 
-_Trusted Committer_ angemessen ist und Du weißt, wie ein _Trusted Committer_ mit anderen Rollen in einem Software-Projekt interagiert, lass uns einen 
+Nachdem Du nun ein grundsätzliches Verständnis von der Rolle hast, wieso der Begriff
+_Trusted Committer_ angemessen ist und Du weißt, wie ein _Trusted Committer_ mit anderen Rollen in einem Software-Projekt interagiert, lass uns einen
 kurzen Blick auf die Verantwortlichkeiten eines _Trusted Committers_ werfen.
 
 === Verantwortlickeiten
@@ -65,4 +65,3 @@ _Trusted Committers_ haben verschiedene Verantwortlichkeiten, unter anderem:
 
 Wir werden diese Verantwortlichkeiten in den folgenden Kapiteln weiter vertiefen, bitte schau Dir dazu auch das Kapitel https://innersourcecommons.org/resources/learningpath/trusted-committer/07/[07 becoming a Trusted Committer] am Ende an.
 [role="pagenumrestart"]
-


### PR DESCRIPTION
Includes a script for substituting article URLs using `urls.yaml`, in case we need to in the future. Had to make a couple of tweaks to urls.yaml to make it work.