### PR TITLE
CONTRIBUTING.md: Update Translation Instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing.  A few tips:
 
 * All articles may be translated into any language of interest.
 * Translated articles should be storied next to the English articles in a subfolder named as the [two-character language code](https://www.loc.gov/standards/iso639-2/php/code_list.php) of the translation (e.g. the `de` subfolder for German).
-* The filename of the article should be translated as well.
+* The filename of the article should be changed to include two-character language code prefix.
 * Issues tracking translations on the [project board](https://github.com/InnerSourceCommons/InnerSourceLearningPath/projects/1) should be labeled with the `Translations` tag as well as the tag of the section being translated (e.g. `Contributor`).
 Here is [an example](https://github.com/InnerSourceCommons/InnerSourceLearningPath/issues/255).
 * Here is the [status of translation efforts](https://github.com/InnerSourceCommons/InnerSourceLearningPath/wiki/Translations). 


### PR DESCRIPTION
I would like to propose to use two-character language code prefix in the file name for translations as follows.
Original: 01-introduction.asciidoc
German translation: de/01-introduction-de.asciidoc
If we use two-character language code in the filename, that makes easier to recognize for other language speaking person when they try to find the files. Also easier to make a regular expression to manipulate it.

$ find . -name '01-intro*' -print
./ja/01-introduction-ja.asciidoc
./de/01-introduction.asciidoc
./01-introduction.asciidoc

The other reason is, using multibyte characters in filename makes difficult to use the filenames from a command line.