### PR TITLE
update the YT urls to the new non-O'Reilly-URLs

### DIFF
--- a/config/urls.yaml
+++ b/config/urls.yaml
@@ -12,7 +12,7 @@
     # URL on the O'Reilly learning plarform.
     oreilly: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321606
     # URL on YouTube.
-    youtube: https://www.youtube.com/watch?v=tP6K5oF2IxQ
+    youtube: https://www.youtube.com/watch?v=l93ohSHhr5U
   article:
     # URL when used as an anchor link in a published PDF.
     anchor: ''
@@ -26,7 +26,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/introduction/02/
     oreilly: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321607
-    youtube: https://www.youtube.com/watch?v=CxsfR_n7JKI
+    youtube: https://www.youtube.com/watch?v=v9fL-E3ZVdc
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/02-problems-solved.asciidoc
@@ -36,7 +36,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/introduction/03/
     oreilly: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321608
-    youtube: https://www.youtube.com/watch?v=E6VVv9S5aKw
+    youtube: https://www.youtube.com/watch?v=jPPwnaEBd8U
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/03-how-works.asciidoc
@@ -46,7 +46,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/introduction/04/
     oreilly: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321609
-    youtube: https://www.youtube.com/watch?v=8LErWYnMfeQ
+    youtube: https://www.youtube.com/watch?v=PFLmOWCEpi4
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/04-benefits.asciidoc
@@ -56,7 +56,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/introduction/05/
     oreilly: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321610
-    youtube: https://www.youtube.com/watch?v=8LErWYnMfeQ
+    youtube: https://www.youtube.com/watch?v=rLiDsM3w5YM
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/05-principles.asciidoc
@@ -66,7 +66,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/introduction/06/
     oreilly: https://learning.oreilly.com/videos/introduction-to-innersource/9781492041504/9781492041504-video321611
-    youtube: https://www.youtube.com/watch?v=8LErWYnMfeQ
+    youtube: https://www.youtube.com/watch?v=cFmg-c9IunM
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/introduction/06-conclusion.asciidoc
@@ -76,7 +76,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/index
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323925
-    youtube: https://www.youtube.com/watch?v=TKdqjkPJWNU
+    youtube: https://www.youtube.com/watch?v=2FdD9Gup6Yc
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/01-introduction.asciidoc
@@ -86,7 +86,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/02/
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323926
-    youtube: https://www.youtube.com/watch?v=06cVAAwgsZA
+    youtube: https://www.youtube.com/watch?v=QQ1z9DHlbhg
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/02-ensuring-product-quality.asciidoc
@@ -96,7 +96,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/03/
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323927
-    youtube: https://www.youtube.com/watch?v=930UIbjiXZc
+    youtube: https://www.youtube.com/watch?v=aLGtTTzkQec
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/03-keeping-the-community-healthy.asciidoc
@@ -106,7 +106,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/04/
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323928
-    youtube: https://www.youtube.com/watch?v=o7geZaX7i7I
+    youtube: https://www.youtube.com/watch?v=452IVT7TKsE
   article:
     anchor: pass:[<a data-type="xref" href="upleveling" data-xrefstyle="chap-num-title">#upleveling</a>]
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/04-uplevelling-community-members.asciidoc
@@ -116,7 +116,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/05/
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323929
-    youtube: https://www.youtube.com/watch?v=Lnz54hlKC-I
+    youtube: https://www.youtube.com/watch?v=0Ztb6k5Y17o
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/05-lowering-the-barriers-to-entry.asciidoc
@@ -126,7 +126,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/06/
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323930
-    youtube: https://www.youtube.com/watch?v=ucQA8mp012Q
+    youtube: https://www.youtube.com/watch?v=sqE-Uif_giA
   article:
     anchor: pass:[<a data-type="xref" href="advocating" data-xrefstyle="chap-num-title">#advocating</a>]
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/06-advocating-for-the-communitys-needs.asciidoc
@@ -136,7 +136,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/07/
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323931
-    youtube: https://www.youtube.com/watch?v=jA1p01FEHj4
+    youtube: https://www.youtube.com/watch?v=nZp8jlr9l-k
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/07-becoming-a-trusted-committer.asciidoc
@@ -146,7 +146,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/trusted-committer/08/
     oreilly: https://learning.oreilly.com/videos/the-trusted-committer/9781492047599/9781492047599-video323932
-    youtube: https://www.youtube.com/watch?v=n982OcEfyQE
+    youtube: https://www.youtube.com/watch?v=qlVpZn_2KMs
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/trusted-committer/08-conclusion.asciidoc
@@ -156,7 +156,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/product-owner/index
     oreilly: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707/9781492046707-video325229
-    youtube: https://www.youtube.com/watch?v=5DXUljspcA4
+    youtube: https://www.youtube.com/watch?v=urbkSMsJXZ0
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/01-opening-article.asciidoc
@@ -166,7 +166,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/product-owner/02/
     oreilly: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707/9781492046707-video325230
-    youtube: https://www.youtube.com/watch?v=qCGCNGHyx9I
+    youtube: https://www.youtube.com/watch?v=PQwlatm5Kak
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/02-how-difficult-it-is-to-be-a-middle-manager-article.asciidoc
@@ -176,7 +176,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/product-owner/03/
     oreilly: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707/9781492046707-video325231
-    youtube: https://www.youtube.com/watch?v=CuycPf1DTVQ
+    youtube: https://www.youtube.com/watch?v=UGX7khGbtx0
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/03-major-benefits-are-built-into-the-innersource-process-article.asciidoc
@@ -186,7 +186,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/product-owner/04/
     oreilly: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707/9781492046707-video325232
-    youtube: https://www.youtube.com/watch?v=35Ttvq1zEAA
+    youtube: https://www.youtube.com/watch?v=afXNJjt2ReI
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/04-new-roles-and-responsibilities-article.asciidoc
@@ -196,7 +196,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/product-owner/05/
     oreilly: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707/9781492046707-video325233
-    youtube: https://www.youtube.com/watch?v=Wxd-SiV5NSI
+    youtube: https://www.youtube.com/watch?v=LO5ouFdgyBY
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/05-recap-takeaways-article.asciidoc
@@ -206,7 +206,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/product-owner/06/
     oreilly: https://learning.oreilly.com/videos/innersource-product-owners/9781492046707/9781492046707-video325234
-    youtube: https://www.youtube.com/watch?v=qMGQVvoqrzo
+    youtube: https://www.youtube.com/watch?v=0beNc9V-tro
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/product-owner/06-closing-and-contact-article.asciidoc
@@ -216,7 +216,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/contributor/index
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329499
-    youtube: https://www.youtube.com/watch?v=_LNtwShi_XI
+    youtube: https://www.youtube.com/watch?v=ncPO1fz5fRg
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc
@@ -226,7 +226,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/contributor/02/
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329500
-    youtube: https://www.youtube.com/watch?v=ofzSDF9EmPU
+    youtube: https://www.youtube.com/watch?v=v3aRZkbTSmY
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/02-becoming-a-contributor-article.asciidoc
@@ -236,7 +236,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/contributor/03/
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329501
-    youtube: https://www.youtube.com/watch?v=PJEAQXcCh4o
+    youtube: https://www.youtube.com/watch?v=iQu-l3j2kCg
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/03-contributor-ethos-article.asciidoc
@@ -246,7 +246,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/contributor/04/
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329502
-    youtube: https://www.youtube.com/watch?v=BxemepTtPz8
+    youtube: https://www.youtube.com/watch?v=wv3uylJC4K0
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/04-mechanics-of-contributing-article.asciidoc
@@ -256,7 +256,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/contributor/05/
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329503
-    youtube: https://www.youtube.com/watch?v=6TGnjmX7zb0
+    youtube: https://www.youtube.com/watch?v=HMBW0B1XPi0
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/05-benefits-of-contribution-article.asciidoc
@@ -266,7 +266,7 @@
   video:
     isc: https://innersourcecommons.org/resources/learningpath/contributor/06/
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329504
-    youtube: https://www.youtube.com/watch?v=_DimaLMLkyk
+    youtube: https://www.youtube.com/watch?v=5SztKQyeUiM
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/06-conclusion-article.asciidoc


### PR DESCRIPTION
Hi, 
I updated the YT urls to the new non-O'Reilly-URLs in the `urls.yaml`, all thumbnails are confirmed by people pictured, see issue #214 

From what I see this is independent of setting publishing times on the videos, currently both kind of videos are unlisted (the old ones with O'Reilly Branding and the new ones without), which means: 

- Anyone with the video link can see this Video --> links will now lead to the non-O'Reilly videos
- This video won't appear on your channel page. It also won't appear in YouTube search results unless someone adds it to a public playlist.

I will set the publishing times of the playlists separately
