### PR TITLE
Generate learning path markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 
 \.DS_Store
 scripts/node_modules
+scripts/introduction
+scripts/trusted-committer
+scripts/contributor
+scripts/product-owner

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 
 \.DS_Store
 scripts/node_modules
-scripts/introduction
-scripts/trusted-committer
-scripts/contributor
-scripts/product-owner
+scripts/learningpath

--- a/product-owner/01-opening-article.asciidoc
+++ b/product-owner/01-opening-article.asciidoc
@@ -1,3 +1,5 @@
+== Opening
+
 Hey, middle managers, product owners, and program managers.
 Do you want to lead happier and more effective teams?
 Would you like to be more of a leader and less of a bookkeeper stuck in reporting hell?

--- a/product-owner/02-how-difficult-it-is-to-be-a-middle-manager-article.asciidoc
+++ b/product-owner/02-how-difficult-it-is-to-be-a-middle-manager-article.asciidoc
@@ -1,3 +1,5 @@
+== How Difficult it is to be Middle Management
+
 So let me first start off by talking to the product owners or middle management people out there watching.
 It is tough being you, and the stats show it.
 If you Google "middle management," most of the results are about how tough it is.

--- a/product-owner/03-major-benefits-are-built-into-the-innersource-process-article.asciidoc
+++ b/product-owner/03-major-benefits-are-built-into-the-innersource-process-article.asciidoc
@@ -1,3 +1,5 @@
+== Major Benefits are Built into the InnerSource Process
+
 In the http://innersourcecommons.org/[InnerSource Commons], we talk about the concept of _open_ in the lessons we've learned in open source, and how we might reuse what we know or have learned in an enterprise environment.
 Let me step through a few of those from a manager's perspective. I'll talk about how they've benefited me as a director, and my product managers - that's what we call product owners at PayPal.
 

--- a/product-owner/04-new-roles-and-responsibilities-article.asciidoc
+++ b/product-owner/04-new-roles-and-responsibilities-article.asciidoc
@@ -1,3 +1,5 @@
+== New Roles and Responsibilities
+
 Being an InnerSource leader comes with new roles and responsibilities.
  One of the first one of those is supporting your TCs. TCs are the https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committers_].
 One of the first things that you're going to be doing is probably helping to choose who those new TCs are going to be and supporting them in their job.

--- a/product-owner/05-recap-takeaways-article.asciidoc
+++ b/product-owner/05-recap-takeaways-article.asciidoc
@@ -1,3 +1,5 @@
+== Recap and Takeaways
+
 Just to wrap up what we talked about in this article, I'd like to do a quick review.
 
 First of all, be kind. Middle management is tough.

--- a/product-owner/06-closing-and-contact-article.asciidoc
+++ b/product-owner/06-closing-and-contact-article.asciidoc
@@ -1,3 +1,5 @@
+== Closing
+
 Please contact us at http://innersourcecommons.org/[innersourcecommon.org], and join us online.
 We have a very active community of over 80 companies.
 Many of those are Fortune 500 companies.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,3 +11,13 @@ For example, to point all links to innersourcecommons.org:
 ```
 node substitute_article_urls.js isc
 ```
+
+## generate_learning_path_markdown.js
+
+A node script to generate markdown files required for hosting Learning Path on innersourcecommons.org.
+
+### Usage:
+```
+npm ci
+node generate_learning_path_markdown.js
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,4 +20,6 @@ A node script to generate markdown files required for hosting Learning Path on i
 ```
 npm ci
 node generate_learning_path_markdown.js
+
+cp -r learningpath/* <path-to-innersourcecommons.org-repo>/resources/learningpath/
 ```

--- a/scripts/generate_learning_path_markdown.js
+++ b/scripts/generate_learning_path_markdown.js
@@ -51,9 +51,15 @@ const sections = [
   },
 ]
 
+try {
+  fs.mkdirSync('./learningpath')
+} catch (e) {
+  console.log(e)
+}
+
 sections.forEach(({ learning_path_group, dirName, workbook, renderArticles }) => {
   const readPath = `../${dirName}`
-  const writePath = `./${dirName}`
+  const writePath = `./learningpath/${dirName}`
   const articles = getArticleFiles(readPath)
 
   try {

--- a/scripts/generate_learning_path_markdown.js
+++ b/scripts/generate_learning_path_markdown.js
@@ -1,0 +1,98 @@
+const fs = require('fs')
+const YAML = require('yaml')
+const { EOL } = require('os')
+
+const getArticleFiles = (path) => {
+  return fs.readdirSync(path).reduce((articles, filename) => {
+    const filePath = `${path}/${filename}`
+    if (fs.lstatSync(filePath).isDirectory()) {
+      return [...articles, getArticleFiles(filePath)]
+    } else if (filePath.match(/\d\d/) && !filePath.includes('-script.asciidoc')) {
+      return [...articles, {
+        filePath,
+        asciiDoc: fs.readFileSync(filePath, 'utf-8')
+      }]
+    } else {
+      return articles
+    }
+  }, [])
+}
+
+const writeMarkdownFile = (filePath, frontMatter) => {
+  const frontMatterTerminator = '---'
+  const output = [frontMatterTerminator, YAML.stringify(frontMatter).trim(), frontMatterTerminator].join(EOL)
+  fs.writeFileSync(filePath, output)
+}
+
+const sections = [
+  {
+    learning_path_group: 'Introduction',
+    dirName: 'introduction',
+    workbook: '01-introduction.asciidoc',
+    renderArticles: true
+  },
+  {
+    learning_path_group: 'Trusted Committer',
+    dirName: 'trusted-committer',
+    workbook: '02-trusted-committer.asciidoc',
+    renderArticles: true
+  },
+  {
+    learning_path_group: 'Contributor',
+    dirName: 'contributor',
+    workbook: '04-contributor.asciidoc',
+    renderArticles: true
+  },
+  {
+    learning_path_group: 'Product Owner',
+    dirName: 'product-owner',
+    workbook: '03-product-owner.asciidoc',
+    renderArticles: false
+  },
+]
+
+sections.forEach(({ learning_path_group, dirName, workbook, renderArticles }) => {
+  const readPath = `../${dirName}`
+  const writePath = `./${dirName}`
+  const articles = getArticleFiles(readPath)
+
+  try {
+    fs.mkdirSync(writePath)
+  } catch (e) {
+    console.log(e)
+  }
+
+  articles.forEach((article) => {
+    if (Array.isArray(article)) {
+      // Handle non-english articles
+    } else {
+      const articleTitle = article.asciiDoc.match(/== (.*)/)[1]
+      const articleNumber = article.filePath.split('/').pop().split('-')[0]
+      const fileName = articleNumber === '01' ? `${writePath}/index.md` : `${writePath}/${articleNumber}.md`
+      let frontMatter = {
+        layout: 'learning-path-page',
+        show_meta: false,
+        title: `Learning Path - ${learning_path_group} - ${articleTitle}`,
+        learning_path_article: renderArticles ? article.filePath.replace('../', '') : undefined,
+        learning_path_group,
+        learning_path_menu_title: `${articleNumber} - ${articleTitle}`,
+        learning_path_position: parseInt(articleNumber)
+      }
+
+      writeMarkdownFile(fileName, frontMatter)
+    }
+  })
+
+  const workbookFileName = `${writePath}/workbook.md`
+  const workbookFrontMatter = {
+    layout: 'learning-path-page',
+    show_meta: false,
+    title: `Learning Path - ${learning_path_group} - Workbook`,
+    learning_path_article: `workbook/${workbook}`,
+    learning_path_group,
+    learning_path_menu_title: `${learning_path_group} Workbook`,
+    learning_path_position: articles.length - articles.filter(Array.isArray).length + 1
+  }
+
+  writeMarkdownFile(workbookFileName, workbookFrontMatter)
+})

--- a/scripts/generate_learning_path_markdown.js
+++ b/scripts/generate_learning_path_markdown.js
@@ -69,7 +69,7 @@ sections.forEach(({ learning_path_group, dirName, workbook, renderArticles }) =>
       const articleTitle = article.asciiDoc.match(/== (.*)/)[1]
       const articleNumber = article.filePath.split('/').pop().split('-')[0]
       const fileName = articleNumber === '01' ? `${writePath}/index.md` : `${writePath}/${articleNumber}.md`
-      let frontMatter = {
+      const frontMatter = {
         layout: 'learning-path-page',
         show_meta: false,
         title: `Learning Path - ${learning_path_group} - ${articleTitle}`,

--- a/scripts/generate_learning_path_markdown.js
+++ b/scripts/generate_learning_path_markdown.js
@@ -91,7 +91,8 @@ sections.forEach(({ learning_path_group, dirName, workbook, renderArticles }) =>
     learning_path_article: `workbook/${workbook}`,
     learning_path_group,
     learning_path_menu_title: `${learning_path_group} Workbook`,
-    learning_path_position: articles.length - articles.filter(Array.isArray).length + 1
+    learning_path_position: articles.length - articles.filter(Array.isArray).length + 1,
+    no_video: true
   }
 
   writeMarkdownFile(workbookFileName, workbookFrontMatter)


### PR DESCRIPTION
Adds a script for generating markdown files required for hosting Learning Path on innersourcecommons.org.

Only supports English articles initially - intent is to extend for non-English as part of #249.
