### PR TITLE
Fixed the broken link of trusted committer

### DIFF
--- a/introduction/03-how-works.asciidoc
+++ b/introduction/03-how-works.asciidoc
@@ -43,4 +43,4 @@ More engineering time stays focused on producing code that solves company proble
 
 === Additional Resources
 
-* The https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/project-roles/trusted-committer.md[Trusted Committer] pattern.
+* The https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer] pattern.

--- a/introduction/de/03-how-works-de.asciidoc
+++ b/introduction/de/03-how-works-de.asciidoc
@@ -44,4 +44,4 @@ In letzter Konsequenz fließt mehr Zeit in Code, der die eigentlichen Unternehme
 
 === Zusätzliche Ressourcen
 
-* Die Mustervorlage https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/project-roles/trusted-committer.md[Trusted Committer].
+* Die Mustervorlage https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer].

--- a/introduction/ja/03-how-works-ja.asciidoc
+++ b/introduction/ja/03-how-works-ja.asciidoc
@@ -44,4 +44,4 @@ https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_�
 
 === その他のリソース
 
-* https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/project-roles/trusted-committer.md[トラステッドコミッター] パターン
+* https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[トラステッドコミッター] パターン

--- a/introduction/zh/03-how-works-zh.asciidoc
+++ b/introduction/zh/03-how-works-zh.asciidoc
@@ -17,4 +17,4 @@
 这个选项对调用团队很有效，因为他们在需要的时候获得了所需的功能，而无需承担解决方案的长期维护负担。这对于维护团队来说是有效的，因为他们能够更好地拓展和服务他们的消费者。它适用于整个公司，因为共享问题的解决方案最终都在共享的、集中维护的位置，任何人都可以使用它们。更多的工程时间集中于生成解决公司问题的代码，而不是花费在特性协商和问题升级过程中。
 
 === 额外的资源
- * https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/project-roles/trusted-committer.md[Trusted Committer] 的模式。
+ * https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer] 的模式。


### PR DESCRIPTION
The trusted committer pattern link is changed, we need to update the link in the learning path. 