### PR TITLE
Switch links to patterns book

### DIFF
--- a/contributor/03-contributor-ethos-article.asciidoc
+++ b/contributor/03-contributor-ethos-article.asciidoc
@@ -72,7 +72,7 @@ host team. Articulate the value that the contribution will bring to their
 ecosystem.
 
 The host team will be the one taking over maintenance for your changes. It makes
-sense to offer to fulfill a https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/30-day-warranty.md[30-day
+sense to offer to fulfill a https://patterns.innersourcecommons.org/p/30-day-warranty[30-day
 warranty]
 on your submission. This can
 alleviate the host team's fear of the Contributors not being available for

--- a/contributor/it/03-contributor-ethos-article-it.asciidoc
+++ b/contributor/it/03-contributor-ethos-article-it.asciidoc
@@ -65,7 +65,7 @@ all'host team. Articola il valore che la contribuzione porterà al loro
 ecosistema.
 
 L'host team sarà quello che si prenderà carico della manutenzione delle modifiche. Ha
-senso offrire per soddisfare una https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/30-day-warranty.md[garanzia a 30 giorni]
+senso offrire per soddisfare una https://patterns.innersourcecommons.org/p/30-day-warranty[garanzia a 30 giorni]
 sulla tua richiesta. Questo può
 alleviare la paura dell'host team nei riguardi dei Contributori non siano disponibili per il supporto nella correzione dei bug dopo la contribuzione.
 

--- a/contributor/ja/03-contributor-ethos-article-ja.asciidoc
+++ b/contributor/ja/03-contributor-ethos-article-ja.asciidoc
@@ -48,7 +48,7 @@ Yonikの https://cwiki.apache.org/confluence/display/solr/HowToContribute[未完
 コントリビューションがホストチームのエコシステムにもたらす価値を明確にしてください。
 
 ホストチームが、あなたの変更に対するメンテナンスを引継ぐことになります。
-あなたの投稿に対して、 https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/30-day-warranty.md[「30日間保証」] を付けることは理にかなっています。
+あなたの投稿に対して、 https://patterns.innersourcecommons.org/p/30-day-warranty[「30日間保証」] を付けることは理にかなっています。
 こうすることで、コントリビューションから時間が経過した後に、バグ修正のサポートをコントリビュータから受けられなくなるというホストチームの不安を軽減することができます。
 
 === ハウスルールを予測して従う

--- a/contributor/outline.asciidoc
+++ b/contributor/outline.asciidoc
@@ -54,7 +54,7 @@ A simple label change in a graph.
 In the same way that real-life hosts don't always appreciate a stranger knocking on their door, some InnerSource hosts appreciate some heads-up before seeing a pull request get opened to their repo.
   *** In all of these interactions, be prepared to "sell" your contribution to the host team.
    **** Articulate the value that the contribution will bring to their ecosystem.
-   **** Offer to fulfill a https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/30-day-warranty.md[30-day warranty] on your submission.
+   **** Offer to fulfill a https://patterns.innersourcecommons.org/p/30-day-warranty[30-day warranty] on your submission.
     ***** This can alleviate the host teams' fear of the contributors not being available for support with fixing bugs after the time on contribution.
  ** Many InnerSource projects outline how they like to be approached by potential _Contributors_ in their `README.md` or `CONTRIBUTING.md` files.
 * Following the rules

--- a/contributor/zh/03-contributor-ethos-zh.asciidoc
+++ b/contributor/zh/03-contributor-ethos-zh.asciidoc
@@ -28,7 +28,7 @@
 
 在所有这些互动中，都要准备好向项目团队“推销”你的贡献。阐明贡献将给他们的生态系统带来价值。
 
-项目团队将接管你的代码进行维护。你得保证有 https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/30-day-warranty.md[_30天保修 _] 在你的提交记录里。这将缓解项目团队对于贡献者贡献代码以后不进行后续的bug修复的担心。
+项目团队将接管你的代码进行维护。你得保证有 https://patterns.innersourcecommons.org/p/30-day-warranty[_30天保修 _] 在你的提交记录里。这将缓解项目团队对于贡献者贡献代码以后不进行后续的bug修复的担心。
 
 ### 预测并遵守内部规则
 

--- a/introduction/03-how-works.asciidoc
+++ b/introduction/03-how-works.asciidoc
@@ -43,4 +43,4 @@ More engineering time stays focused on producing code that solves company proble
 
 === Additional Resources
 
-* The https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer] pattern.
+* The https://patterns.innersourcecommons.org/p/trusted-committer[Trusted Committer] pattern.

--- a/introduction/de/03-how-works-de.asciidoc
+++ b/introduction/de/03-how-works-de.asciidoc
@@ -44,4 +44,4 @@ In letzter Konsequenz fließt mehr Zeit in Code, der die eigentlichen Unternehme
 
 === Zusätzliche Ressourcen
 
-* Die Mustervorlage https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer].
+* Die Mustervorlage https://patterns.innersourcecommons.org/p/trusted-committer[Trusted Committer].

--- a/introduction/it/03-how-works.asciidoc
+++ b/introduction/it/03-how-works.asciidoc
@@ -43,4 +43,4 @@ Più tempo di progettazione rimane focalizzato sulla produzione del codice che r
 
 === Additional Resources
 
-* Il pattern del https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer].
+* Il pattern del https://patterns.innersourcecommons.org/p/trusted-committer[Trusted Committer].

--- a/introduction/ja/03-how-works-ja.asciidoc
+++ b/introduction/ja/03-how-works-ja.asciidoc
@@ -44,4 +44,4 @@ https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_�
 
 === その他のリソース
 
-* https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[トラステッドコミッター] パターン
+* https://patterns.innersourcecommons.org/p/trusted-committer[トラステッドコミッター] パターン

--- a/introduction/ru/03-how-works.asciidoc
+++ b/introduction/ru/03-how-works.asciidoc
@@ -42,4 +42,4 @@ InnerSource предполагает, что в команде существу�
 
 === Дополнительные ресурсы
 
-* https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer] паттерн.
+* https://patterns.innersourcecommons.org/p/trusted-committer[Trusted Committer] паттерн.

--- a/introduction/zh/03-how-works-zh.asciidoc
+++ b/introduction/zh/03-how-works-zh.asciidoc
@@ -17,4 +17,4 @@
 这个选项对调用团队很有效，因为他们在需要的时候获得了所需的功能，而无需承担解决方案的长期维护负担。这对于维护团队来说是有效的，因为他们能够更好地拓展和服务他们的消费者。它适用于整个公司，因为共享问题的解决方案最终都在共享的、集中维护的位置，任何人都可以使用它们。更多的工程时间集中于生成解决公司问题的代码，而不是花费在特性协商和问题升级过程中。
 
 === 额外的资源
- * https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/trusted-committer.md[Trusted Committer] 的模式。
+ * https://patterns.innersourcecommons.org/p/trusted-committer[Trusted Committer] 的模式。

--- a/workbook/04-contributor.asciidoc
+++ b/workbook/04-contributor.asciidoc
@@ -68,7 +68,7 @@ Why 3 is correct: InnerSource stresses the creation of documentation, both as ba
 
 Why 4 is incorrect: Getting your contribution accepted is an achievement to be celebrated.
 However, your involvement does not end there. 
-You should plan to be available at a minimum to fulfil a https://github.com/InnerSourceCommons/InnerSourcePatterns/blob/master/patterns/2-structured/30-day-warranty.md[30-day warranty] on your changes (and their impact), or even better: stay close to the community and help out with additional contributions. 
+You should plan to be available at a minimum to fulfil a https://patterns.innersourcecommons.org/p/30-day-warranty[30-day warranty] on your changes (and their impact), or even better: stay close to the community and help out with additional contributions.
 
 ===== Question 2.  Which of the following attitudes helps a contributor build a positive relationship with the community?
 


### PR DESCRIPTION
Rather than pointing to patterns in the InnerSourcePatterns GitHub repo, point to the online book at https://patterns.innersourcecommons.org

Implements #373 