### PR TITLE
Adds a machine translation of the introduction articles and index.md to French using DeepL

### DIFF
--- a/introduction/fr/01-introduction.asciidoc
+++ b/introduction/fr/01-introduction.asciidoc
@@ -1,13 +1,13 @@
 == Introduction
 
-Ce parcours d'apprentissage donne une introduction à InnerSource.
-InnerSource est l'application des pratiques et principes de l'open source au développement de logiciels au sein de l'entreprise.
-Le logiciel InnerSource reste propriétaire de l'entreprise, mais à l'intérieur, il est ouvert pour que tout le monde puisse l'utiliser et y contribuer.
-Cette stratégie permet une collaboration large et efficace, produisant des logiciels qui sont réactifs et agiles aux besoins changeants de ses nombreuses parties prenantes internes.
+Ce parcours d'apprentissage est une introduction à l'InnerSource
+L'innerSource est la mise en oeuvre des pratiques et des principes de l'Open Source du développement logiciel au sein de l'entreprise.
+Le logiciel en InnerSource reste la propriété de l'entreprise, mais au sein de celle-ci le code du logiciel est ouvert et accessible pour que tout le monde puisse l'utiliser et y contribuer.
+Cette stratégie permet une collaboration large et efficace, pour produire des logiciels qui sont réactifs et agiles aux besoins changeants des nombreuses parties prenantes internes.
 
-Ce parcours d'apprentissage enseigne comment reconnaître les situations qui sont de bons candidats pour InnerSource.
-Nous décrirons à un haut niveau comment InnerSource peut aider dans ces situations.
-Vous vous familiariserez avec les termes communs utilisés lors des discussions sur InnerSource.
-Nous énumérerons également les principes clés sur lesquels InnerSource est fondée et les avantages constatés lorsqu'elle est appliquée efficacement.
+Ce parcours d'apprentissage enseigne comment reconnaître les situations qui sont de bonnes candidates pour l'InnerSource.
+Nous décrirons à un haut niveau comment l'InnerSource peut aider dans ces situations.
+Vous vous familiariserez avec les termes communs utilisés lors des discussions sur l'InnerSource
+Nous énumérerons également les principes clés sur lesquels l'InnerSource est fondé et les avantages constatés lorsqu'il est appliqué efficacement.
 
 Traduit avec www.DeepL.com/Translator (version gratuite)

--- a/introduction/fr/01-introduction.asciidoc
+++ b/introduction/fr/01-introduction.asciidoc
@@ -1,11 +1,11 @@
 == Introduction
 
 Ce parcours d'apprentissage est une introduction à l'InnerSource
-L'innerSource est la mise en oeuvre des pratiques et des principes de l'Open Source du développement logiciel au sein de l'entreprise.
+L'InnerSource est la mise en oeuvre des pratiques et des principes du développement logiciel de l'Open Source au sein de l'entreprise.
 Le logiciel en InnerSource reste la propriété de l'entreprise, mais au sein de celle-ci le code du logiciel est ouvert et accessible pour que tout le monde puisse l'utiliser et y contribuer.
 Cette stratégie permet une collaboration large et efficace, pour produire des logiciels qui sont réactifs et agiles aux besoins changeants des nombreuses parties prenantes internes.
 
-Ce parcours d'apprentissage enseigne comment reconnaître les situations qui sont de bonnes candidates pour l'InnerSource.
+Ce parcours d'apprentissage apprend à reconnaître les situations qui sont de bonnes candidates pour l'InnerSource.
 Nous décrirons à un haut niveau comment l'InnerSource peut aider dans ces situations.
 Vous vous familiariserez avec les termes communs utilisés lors des discussions sur l'InnerSource
 Nous énumérerons également les principes clés sur lesquels l'InnerSource est fondé et les avantages constatés lorsqu'il est appliqué efficacement.

--- a/introduction/fr/01-introduction.asciidoc
+++ b/introduction/fr/01-introduction.asciidoc
@@ -1,0 +1,13 @@
+== Introduction
+
+Ce parcours d'apprentissage donne une introduction à InnerSource.
+InnerSource est l'application des pratiques et principes de l'open source au développement de logiciels au sein de l'entreprise.
+Le logiciel InnerSource reste propriétaire de l'entreprise, mais à l'intérieur, il est ouvert pour que tout le monde puisse l'utiliser et y contribuer.
+Cette stratégie permet une collaboration large et efficace, produisant des logiciels qui sont réactifs et agiles aux besoins changeants de ses nombreuses parties prenantes internes.
+
+Ce parcours d'apprentissage enseigne comment reconnaître les situations qui sont de bons candidats pour InnerSource.
+Nous décrirons à un haut niveau comment InnerSource peut aider dans ces situations.
+Vous vous familiariserez avec les termes communs utilisés lors des discussions sur InnerSource.
+Nous énumérerons également les principes clés sur lesquels InnerSource est fondée et les avantages constatés lorsqu'elle est appliquée efficacement.
+
+Traduit avec www.DeepL.com/Translator (version gratuite)

--- a/introduction/fr/02-problèmes-résolus.asciidoc
+++ b/introduction/fr/02-problèmes-résolus.asciidoc
@@ -28,7 +28,7 @@ Cependant, elle reste un frein pour l'équipe, car elle détourne nécessairemen
 De plus, cette option n'est pas évolutive, car il n'y a qu'un nombre limité de fois où un consommateur peut faire remonter des demandes de fonctionnalités avant de nuire à sa crédibilité.
 L'escalade est tout aussi perturbante (voire plus) pour les membres de l'équipe de production, qui sont sortis de leur flux de travail normal et de leurs méthodes de priorisation pour traiter la demande de fonctionnalité escaladée.
 
-Cette discussion ouvre la voie à InnerSource.
+Cette discussion ouvre la voie à l'InnerSource.
 L'InnerSource s'applique au même type de situation où une équipe consommatrice est incapable d'obtenir ce dont elle a besoin via une demande de fonctionnalité.
 L'InnerSource permet aux équipes de bénéficier des avantages de l'attente, du contournement et de l'escalade sans les inconvénients associés.
 

--- a/introduction/fr/02-problèmes-résolus.asciidoc
+++ b/introduction/fr/02-problèmes-résolus.asciidoc
@@ -1,6 +1,6 @@
-== Quels problèmes InnerSource résout-il ?
+== Quels problèmes l'InnerSource peut-il résoudre ?
 
-InnerSource encourage et récompense la collaboration et la réutilisation du code avec quiconque, quelle que soit sa position dans la structure organisationnelle de l'entreprise.
+L'InnerSource encourage et récompense la collaboration et la réutilisation du code avec quiconque, quelle que soit sa position dans la structure organisationnelle de l'entreprise.
 Cette approche diffère de ce que l'on voit dans les organisations traditionnelles où les idées et le produit du travail ont tendance à rester enfermés dans les limites de la hiérarchie interne de l'entreprise et de ses silos.
 Explorons une situation qui donne un exemple de cette idée.
 
@@ -11,11 +11,11 @@ Cette situation est courante dans une grande entreprise où une seule équipe pr
 Lorsque les équipes consommatrices ont besoin de nombreuses fonctionnalités, les équipes productrices ont normalement une sorte de processus de définition des besoins et de hiérarchisation des priorités pour décider sur quelles fonctionnalités elles vont travailler.
 Pour les demandes de fonctionnalités critiques qui ne sont pas prioritaires pour un travail immédiat, l'équipe consommatrice peut généralement choisir l'une des trois options suivantes, chacune présentant ses propres inconvénients.
 
-. *Attendre. L'équipe utilisatrice peut ne rien faire et rester sans la fonctionnalité demandée.
+. *L'attente.. L'équipe utilisatrice peut ne rien faire et rester sans la fonctionnalité demandée.
   Cette option exige le moins de travail de leur part.
   Selon l'intérêt de la demande de fonctionnalité, l'attente peut être tout à fait acceptable.
   Toutefois, elle peut s'accompagner d'une réelle souffrance, surtout si la fonctionnalité demandée n'est jamais livrée.
-. *Workaround*. Une équipe de consommateurs qui ne veut pas attendre peut faire du travail supplémentaire ailleurs pour compenser l'absence de la fonctionnalité demandée.
+. *solution de contournement*. Une équipe de consommateurs qui ne veut pas attendre peut faire un travail supplémentaire ailleurs, pour compenser l'absence de la fonctionnalité demandée.
   Ce travail supplémentaire peut prendre la forme d'un changement dans le projet de consommation.
   Elle peut aussi créer un nouveau projet qui répond à ses besoins et remplace l'utilisation de tout ou partie du système de l'équipe productrice (duplication de code/projet).
   Cette stratégie permet à l'équipe consommatrice d'obtenir la fonctionnalité demandée uniquement par ses propres efforts. Elle présente cependant plusieurs inconvénients.
@@ -29,10 +29,10 @@ De plus, cette option n'est pas évolutive, car il n'y a qu'un nombre limité de
 L'escalade est tout aussi perturbante (voire plus) pour les membres de l'équipe de production, qui sont sortis de leur flux de travail normal et de leurs méthodes de priorisation pour traiter la demande de fonctionnalité escaladée.
 
 Cette discussion ouvre la voie à InnerSource.
-InnerSource s'applique au même type de situation où une équipe consommatrice est incapable d'obtenir ce dont elle a besoin via une demande de fonctionnalité.
-InnerSource permet aux équipes de bénéficier des avantages de l'attente, du contournement et de l'escalade sans les inconvénients associés.
+L'InnerSource s'applique au même type de situation où une équipe consommatrice est incapable d'obtenir ce dont elle a besoin via une demande de fonctionnalité.
+L'InnerSource permet aux équipes de bénéficier des avantages de l'attente, du contournement et de l'escalade sans les inconvénients associés.
 
-InnerSource apporte également une amélioration générale de la culture d'ingénierie car les ingénieurs ont la possibilité de travailler avec une plus grande variété de nouvelles technologies et de personnes.
+L'InnerSource apporte également une amélioration générale de la culture d'ingénierie car les ingénieurs ont la possibilité de travailler avec une plus grande variété de nouvelles technologies et de personnes.
 Les développeurs se conseillent et apprennent les uns des autres en partageant des idées et des solutions au-delà des silos organisationnels.
 Les ingénieurs et les équipes peuvent réutiliser les solutions internes aux problèmes de base, ce qui leur permet de se concentrer sur des flux de travail à plus forte valeur ajoutée pour l'organisation.
 

--- a/introduction/fr/02-problèmes-résolus.asciidoc
+++ b/introduction/fr/02-problèmes-résolus.asciidoc
@@ -1,0 +1,39 @@
+== Quels problèmes InnerSource résout-il ?
+
+InnerSource encourage et récompense la collaboration et la réutilisation du code avec quiconque, quelle que soit sa position dans la structure organisationnelle de l'entreprise.
+Cette approche diffère de ce que l'on voit dans les organisations traditionnelles où les idées et le produit du travail ont tendance à rester enfermés dans les limites de la hiérarchie interne de l'entreprise et de ses silos.
+Explorons une situation qui donne un exemple de cette idée.
+
+Imaginez que deux équipes d'une même entreprise produisent des logiciels distincts, le logiciel de l'une dépendant de celui de l'autre.
+Un exemple pourrait être une expérience utilisateur qui dépend d'un service API pour récupérer des données à afficher.
+Cette situation est courante dans une grande entreprise où une seule équipe produisant un logiciel peut avoir des dizaines ou des centaines de consommateurs.
+
+Lorsque les équipes consommatrices ont besoin de nombreuses fonctionnalités, les équipes productrices ont normalement une sorte de processus de définition des besoins et de hiérarchisation des priorités pour décider sur quelles fonctionnalités elles vont travailler.
+Pour les demandes de fonctionnalités critiques qui ne sont pas prioritaires pour un travail immédiat, l'équipe consommatrice peut généralement choisir l'une des trois options suivantes, chacune présentant ses propres inconvénients.
+
+. *Attendre. L'équipe utilisatrice peut ne rien faire et rester sans la fonctionnalité demandée.
+  Cette option exige le moins de travail de leur part.
+  Selon l'intérêt de la demande de fonctionnalité, l'attente peut être tout à fait acceptable.
+  Toutefois, elle peut s'accompagner d'une réelle souffrance, surtout si la fonctionnalité demandée n'est jamais livrée.
+. *Workaround*. Une équipe de consommateurs qui ne veut pas attendre peut faire du travail supplémentaire ailleurs pour compenser l'absence de la fonctionnalité demandée.
+  Ce travail supplémentaire peut prendre la forme d'un changement dans le projet de consommation.
+  Elle peut aussi créer un nouveau projet qui répond à ses besoins et remplace l'utilisation de tout ou partie du système de l'équipe productrice (duplication de code/projet).
+  Cette stratégie permet à l'équipe consommatrice d'obtenir la fonctionnalité demandée uniquement par ses propres efforts. Elle présente cependant plusieurs inconvénients.
+ .. Tout travail effectué par l'équipe consommatrice reste indisponible pour tout autre consommateur ayant la même demande de fonctionnalité.
+ .. L'équipe consommatrice s'est engagée par inadvertance à assumer la charge à long terme de la maintenance du code nouvellement écrit, ce qui ne relève pas du domaine de compétence de son équipe principale.
+ .. L'entreprise dans son ensemble acquiert des projets et du code en double dans le même espace de problèmes.
+. *Escalade*. L'équipe consommatrice peut ne pas accepter un "non" comme réponse et, au lieu de cela, plaider auprès de quelqu'un dans la hiérarchie de gestion des producteurs pour influencer (ou forcer) l'équipe productrice à faire le travail.
+Cette option semble attrayante pour l'équipe utilisatrice, car elle obtient la fonctionnalité demandée sans avoir à faire le travail de mise en œuvre ou de maintenance.
+Cependant, elle reste un frein pour l'équipe, car elle détourne nécessairement une partie de son attention et de son travail vers la tâche non technique de l'escalade.
+De plus, cette option n'est pas évolutive, car il n'y a qu'un nombre limité de fois où un consommateur peut faire remonter des demandes de fonctionnalités avant de nuire à sa crédibilité.
+L'escalade est tout aussi perturbante (voire plus) pour les membres de l'équipe de production, qui sont sortis de leur flux de travail normal et de leurs méthodes de priorisation pour traiter la demande de fonctionnalité escaladée.
+
+Cette discussion ouvre la voie à InnerSource.
+InnerSource s'applique au même type de situation où une équipe consommatrice est incapable d'obtenir ce dont elle a besoin via une demande de fonctionnalité.
+InnerSource permet aux équipes de bénéficier des avantages de l'attente, du contournement et de l'escalade sans les inconvénients associés.
+
+InnerSource apporte également une amélioration générale de la culture d'ingénierie car les ingénieurs ont la possibilité de travailler avec une plus grande variété de nouvelles technologies et de personnes.
+Les développeurs se conseillent et apprennent les uns des autres en partageant des idées et des solutions au-delà des silos organisationnels.
+Les ingénieurs et les équipes peuvent réutiliser les solutions internes aux problèmes de base, ce qui leur permet de se concentrer sur des flux de travail à plus forte valeur ajoutée pour l'organisation.
+
+Traduit avec www.DeepL.com/Translator (version gratuite)

--- a/introduction/fr/03-comment fonctionne.asciidoc
+++ b/introduction/fr/03-comment fonctionne.asciidoc
@@ -1,0 +1,48 @@
+== Comment fonctionne InnerSource ?
+
+Disons que l'équipe A utilise un logiciel produit par l'équipe B.
+L'équipe A soumet une demande de fonctionnalité à l'équipe B, mais l'équipe B n'est pas en mesure d'implémenter cette fonctionnalité à temps pour l'équipe A.
+Dans un environnement InnerSource, si l'équipe A ne peut pas obtenir cette demande de fonctionnalité, elle soumet une demande de retrait à la place.
+C'est-à-dire que l'équipe A implémente la fonctionnalité directement dans le logiciel de l'équipe B et soumet une demande d'extraction avec les changements de code.
+L'équipe B s'associe pour examiner et accepter le code soumis.
+
+Dans cet exemple, nous appelons l'équipe A l'équipe _Invité_ et l'équipe B l'équipe _Hôte_.
+Les termes _Invité_ et _Hôte_ suggèrent une situation analogue à la réception d'un visiteur à la maison.
+Dans cette situation, la plupart des gens veulent être de bons hôtes.
+Ils veillent à ce que tout soit bien rangé et ordonné en prévision de l'arrivée de leurs invités.
+Les visiteurs sont accueillis à la porte et invités à entrer.
+Ils peuvent utiliser les équipements et les services qui se trouvent dans les parties communes de la maison.
+Il peut y avoir quelques règles de la maison que les invités sont priés de suivre.
+De même, la plupart des hôtes veulent faire preuve de respect envers la maison et leur hôte.
+Ils font attention aux objets de la maison et suivent les règles pendant toute la durée de leur séjour.
+Ils peuvent espérer ou attendre une invitation de retour, à condition d'avoir été courtois et polis.
+Ces concepts relatifs à la visite d'une maison sont une métaphore de l'attitude et des comportements que les équipes doivent adopter lorsqu'elles accueillent une autre personne qui contribue à la base de code.
+
+Regardons de plus près comment les mécanismes du processus InnerSource peuvent fonctionner.
+Pour faciliter cette explication, nous allons nommer quelques personnes clés dans les équipes invitées et hôtes.
+Tout d'abord, le https://innersourcecommons.org/learn/learning-path/product-owner/01[_Propriétaire du produit_] détermine quelle fonctionnalité l'équipe hôte est prête à accepter comme contribution.
+Le https://innersourcecommons.org/learn/learning-path/contributor/01[_Contributeur_] est la personne de l'équipe invitée qui soumet la contribution au code à l'équipe hôte pour examen.
+Le https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_Trusted Committer_] représente l'équipe hôte en fournissant le soutien et l'encadrement dont le contributeur a besoin pour soumettre avec succès la demande de retrait.
+Dans le cas de petits projets de base, une seule personne remplit souvent les rôles de propriétaire du produit et de commiteur de confiance.
+
+Avec ces définitions, voici le schéma de base d'une contribution InnerSource.
+
+* L'équipe ou le contributeur invité demande une fonctionnalité à l'équipe hôte.
+* Le propriétaire du produit s'assure que les histoires d'utilisateur représentant la demande de fonctionnalité sont créées, soit par les membres de l'équipe invitée, soit par l'équipe hôte.
+Ces histoires doivent décrire la fonctionnalité demandée dans des termes acceptables pour l'équipe invitée.
+Ils énumèrent également tous les détails fournis par l'équipe hôte sur la manière dont la fonctionnalité doit être fournie pour que le travail soit accepté.
+Les exemples de tels détails incluent les contraintes d'architecture, les conventions de codage, l'utilisation des dépendances, les contrats de données, etc.
+* Soutenu par le commettant de confiance, le contributeur soumet la demande de modification pour implémenter la fonctionnalité demandée.
+
+Notez que ces étapes ne supposent pas un système spécifique pour l'organisation générale du temps ou des priorités d'une équipe. InnerSource part du principe que les équipes ont déjà des méthodes d'organisation existantes et fournit un cadre pour les utiliser afin de travailler ensemble lorsqu'une équipe invitée souhaite contribuer au code d'un hôte.
+
+Cette option fonctionne bien pour l'équipe invitée car elle obtient la fonctionnalité dont elle a besoin au moment où elle en a besoin sans avoir à assumer le fardeau à long terme de la maintenance de la solution.
+Elle fonctionne pour l'équipe hôte car elle est en mesure de mieux évoluer et de mieux servir ses clients.
+Pour l'entreprise dans son ensemble, car les solutions aux problèmes partagés se retrouvent dans des emplacements partagés, maintenus de manière centralisée, où tout le monde peut les utiliser.
+Plus de temps d'ingénierie est consacré à la production de code qui résout les problèmes de l'entreprise plutôt qu'à la mécanique de la négociation des fonctionnalités et au processus d'escalade.
+
+=== Ressources supplémentaires
+
+* Le modèle https://patterns.innersourcecommons.org/p/trusted-committer [Trusted Committer].
+
+Traduit avec www.DeepL.com/Translator (version gratuite)

--- a/introduction/fr/03-comment fonctionne.asciidoc
+++ b/introduction/fr/03-comment fonctionne.asciidoc
@@ -1,4 +1,4 @@
-== Comment fonctionne InnerSource ?
+== Comment fonctionne l'Innersource ?
 
 Disons que l'équipe A utilise un logiciel produit par l'équipe B.
 L'équipe A soumet une demande de fonctionnalité à l'équipe B, mais l'équipe B n'est pas en mesure d'implémenter cette fonctionnalité à temps pour l'équipe A.
@@ -6,8 +6,8 @@ Dans un environnement InnerSource, si l'équipe A ne peut pas obtenir cette dema
 C'est-à-dire que l'équipe A implémente la fonctionnalité directement dans le logiciel de l'équipe B et soumet une demande d'extraction avec les changements de code.
 L'équipe B s'associe pour examiner et accepter le code soumis.
 
-Dans cet exemple, nous appelons l'équipe A l'équipe _Invité_ et l'équipe B l'équipe _Hôte_.
-Les termes _Invité_ et _Hôte_ suggèrent une situation analogue à la réception d'un visiteur à la maison.
+Dans cet exemple, nous appelons l'équipe A l'équipe _Invitée_ et l'équipe B l'équipe _Hôte_.
+Les termes _Invitée_ et _Hôte_ suggèrent une situation analogue à la réception d'un visiteur à la maison.
 Dans cette situation, la plupart des gens veulent être de bons hôtes.
 Ils veillent à ce que tout soit bien rangé et ordonné en prévision de l'arrivée de leurs invités.
 Les visiteurs sont accueillis à la porte et invités à entrer.
@@ -22,19 +22,19 @@ Regardons de plus près comment les mécanismes du processus InnerSource peuvent
 Pour faciliter cette explication, nous allons nommer quelques personnes clés dans les équipes invitées et hôtes.
 Tout d'abord, le https://innersourcecommons.org/learn/learning-path/product-owner/01[_Propriétaire du produit_] détermine quelle fonctionnalité l'équipe hôte est prête à accepter comme contribution.
 Le https://innersourcecommons.org/learn/learning-path/contributor/01[_Contributeur_] est la personne de l'équipe invitée qui soumet la contribution au code à l'équipe hôte pour examen.
-Le https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_Trusted Committer_] représente l'équipe hôte en fournissant le soutien et l'encadrement dont le contributeur a besoin pour soumettre avec succès la demande de retrait.
-Dans le cas de petits projets de base, une seule personne remplit souvent les rôles de propriétaire du produit et de commiteur de confiance.
+Le https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_Trusted Committer_] représente l'équipe hôte en fournissant le soutien et l'encadrement dont le contributeur a besoin pour soumettre avec succès la demande d'évolution du code.
+Dans le cas de petits projets de base, une seule personne remplit souvent les rôles de propriétaire du produit et de commiteur de confiance (Trusted comitter).
 
 Avec ces définitions, voici le schéma de base d'une contribution InnerSource.
 
 * L'équipe ou le contributeur invité demande une fonctionnalité à l'équipe hôte.
-* Le propriétaire du produit s'assure que les histoires d'utilisateur représentant la demande de fonctionnalité sont créées, soit par les membres de l'équipe invitée, soit par l'équipe hôte.
+* Le propriétaire du produit s'assure que les histoires d'utilisateur (Users Stories) représentant la demande de fonctionnalité sont créées, soit par les membres de l'équipe invitée, soit par l'équipe hôte
 Ces histoires doivent décrire la fonctionnalité demandée dans des termes acceptables pour l'équipe invitée.
 Ils énumèrent également tous les détails fournis par l'équipe hôte sur la manière dont la fonctionnalité doit être fournie pour que le travail soit accepté.
 Les exemples de tels détails incluent les contraintes d'architecture, les conventions de codage, l'utilisation des dépendances, les contrats de données, etc.
-* Soutenu par le commettant de confiance, le contributeur soumet la demande de modification pour implémenter la fonctionnalité demandée.
+* Soutenu par le commiter de confiance, le contributeur soumet la demande de modification pour implémenter la fonctionnalité demandée.
 
-Notez que ces étapes ne supposent pas un système spécifique pour l'organisation générale du temps ou des priorités d'une équipe. InnerSource part du principe que les équipes ont déjà des méthodes d'organisation existantes et fournit un cadre pour les utiliser afin de travailler ensemble lorsqu'une équipe invitée souhaite contribuer au code d'un hôte.
+Notez que ces étapes ne supposent pas un système spécifique pour l'organisation générale du temps ou des priorités d'une équipe. L'InnerSource part du principe que les équipes ont déjà des méthodes d'organisation existantes et fournit un cadre pour les utiliser afin de travailler ensemble lorsqu'une équipe invitée souhaite contribuer au code d'un hôte.
 
 Cette option fonctionne bien pour l'équipe invitée car elle obtient la fonctionnalité dont elle a besoin au moment où elle en a besoin sans avoir à assumer le fardeau à long terme de la maintenance de la solution.
 Elle fonctionne pour l'équipe hôte car elle est en mesure de mieux évoluer et de mieux servir ses clients.

--- a/introduction/fr/03-comment fonctionne.asciidoc
+++ b/introduction/fr/03-comment fonctionne.asciidoc
@@ -2,8 +2,8 @@
 
 Disons que l'équipe A utilise un logiciel produit par l'équipe B.
 L'équipe A soumet une demande de fonctionnalité à l'équipe B, mais l'équipe B n'est pas en mesure d'implémenter cette fonctionnalité à temps pour l'équipe A.
-Dans un environnement InnerSource, si l'équipe A ne peut pas obtenir cette demande de fonctionnalité, elle soumet une demande de retrait à la place.
-C'est-à-dire que l'équipe A implémente la fonctionnalité directement dans le logiciel de l'équipe B et soumet une demande d'extraction avec les changements de code.
+Dans un environnement InnerSource, si l'équipe A ne peut pas obtenir cette demande de fonctionnalité, elle soumet une demande d'évolution (PR) à la place.
+C'est-à-dire que l'équipe A implémente la fonctionnalité directement dans le logiciel de l'équipe B et soumet une demande d'évolution avec les changements de code.
 L'équipe B s'associe pour examiner et accepter le code soumis.
 
 Dans cet exemple, nous appelons l'équipe A l'équipe _Invitée_ et l'équipe B l'équipe _Hôte_.
@@ -15,24 +15,24 @@ Ils peuvent utiliser les équipements et les services qui se trouvent dans les p
 Il peut y avoir quelques règles de la maison que les invités sont priés de suivre.
 De même, la plupart des hôtes veulent faire preuve de respect envers la maison et leur hôte.
 Ils font attention aux objets de la maison et suivent les règles pendant toute la durée de leur séjour.
-Ils peuvent espérer ou attendre une invitation de retour, à condition d'avoir été courtois et polis.
-Ces concepts relatifs à la visite d'une maison sont une métaphore de l'attitude et des comportements que les équipes doivent adopter lorsqu'elles accueillent une autre personne qui contribue à la base de code.
+Ils peuvent espérer ou attendre une invitation en retour, à condition d'avoir été courtois et polis.
+Ces concepts relatifs à la visite d'une maison sont une métaphore de l'attitude et des comportements que les équipes doivent adopter lorsqu'elles accueillent une autre personne qui contribue à la base du code.
 
 Regardons de plus près comment les mécanismes du processus InnerSource peuvent fonctionner.
 Pour faciliter cette explication, nous allons nommer quelques personnes clés dans les équipes invitées et hôtes.
 Tout d'abord, le https://innersourcecommons.org/learn/learning-path/product-owner/01[_Propriétaire du produit_] détermine quelle fonctionnalité l'équipe hôte est prête à accepter comme contribution.
 Le https://innersourcecommons.org/learn/learning-path/contributor/01[_Contributeur_] est la personne de l'équipe invitée qui soumet la contribution au code à l'équipe hôte pour examen.
 Le https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_Trusted Committer_] représente l'équipe hôte en fournissant le soutien et l'encadrement dont le contributeur a besoin pour soumettre avec succès la demande d'évolution du code.
-Dans le cas de petits projets de base, une seule personne remplit souvent les rôles de propriétaire du produit et de commiteur de confiance (Trusted comitter).
+Dans le cas de petits projets de base, une seule personne remplit souvent les rôles de propriétaire du produit et de committeur de confiance (Trusted committer).
 
 Avec ces définitions, voici le schéma de base d'une contribution InnerSource.
 
 * L'équipe ou le contributeur invité demande une fonctionnalité à l'équipe hôte.
-* Le propriétaire du produit s'assure que les histoires d'utilisateur (Users Stories) représentant la demande de fonctionnalité sont créées, soit par les membres de l'équipe invitée, soit par l'équipe hôte
+* Le propriétaire du produit s'assure que les histoires d'utilisateur (Users Stories) représentant la demande de fonctionnalité sont créées, soit par les membres de l'équipe invitée, soit par l'équipe hôte.
 Ces histoires doivent décrire la fonctionnalité demandée dans des termes acceptables pour l'équipe invitée.
-Ils énumèrent également tous les détails fournis par l'équipe hôte sur la manière dont la fonctionnalité doit être fournie pour que le travail soit accepté.
+Ils listent également tous les détails fournis par l'équipe hôte sur la manière dont la fonctionnalité devrait être livrée pour que le travail soit accepté.
 Les exemples de tels détails incluent les contraintes d'architecture, les conventions de codage, l'utilisation des dépendances, les contrats de données, etc.
-* Soutenu par le commiter de confiance, le contributeur soumet la demande de modification pour implémenter la fonctionnalité demandée.
+Soutenu par le committer de confiance, le contributeur soumet la demande d'évolution pour implémenter la fonctionnalité demandée.
 
 Notez que ces étapes ne supposent pas un système spécifique pour l'organisation générale du temps ou des priorités d'une équipe. L'InnerSource part du principe que les équipes ont déjà des méthodes d'organisation existantes et fournit un cadre pour les utiliser afin de travailler ensemble lorsqu'une équipe invitée souhaite contribuer au code d'un hôte.
 

--- a/introduction/fr/04-avantages.asciidoc
+++ b/introduction/fr/04-avantages.asciidoc
@@ -1,0 +1,31 @@
+== Quels sont les avantages d'InnerSource ?
+
+Il existe de nombreux avantages à collaborer via InnerSource.
+InnerSource offre à une entreprise une stratégie évolutive permettant aux *équipes invitées d'obtenir des demandes de fonctionnalités lorsqu'elles en ont besoin*, sans le fardeau à long terme de la maintenance.
+L'entreprise dans son ensemble est gagnante car le temps des équipes invitées est mis dans un code que d'autres peuvent utiliser.
+
+Bien que ce résultat soit un avantage indéniable d'InnerSource, il existe de nombreux avantages pour les hôtes qui reçoivent régulièrement des contributions d'InnerSource.
+Rappelez-vous que, dans le cadre du processus d'InnerSource, le propriétaire du produit de l'équipe hôte convient dès le départ que les fonctions contribuées sont bonnes et souhaitables.
+InnerSource permet à l'équipe hôte de recevoir *une aide pour créer un meilleur produit* pour ses consommateurs !
+
+*InnerSource fournit à l'équipe hôte une stratégie évolutive* pour répondre à des quantités variables de fonctionnalités demandées par ses nombreux clients.
+Compte tenu de la capacité fixe des membres à temps plein de l'équipe hôte, il est probable que, parfois, les feuilles de route commerciales combinées de ses consommateurs exigent que des quantités très (ou même déraisonnablement) importantes de travail soient effectuées dans les produits de l'équipe hôte.
+Sans InnerSource, cette situation peut facilement conduire à une équipe stressée et surchargée de travail qui doit faire face à de nombreuses demandes de fonctionnalités transmises à ses dirigeants.
+
+Cependant, si l'équipe hôte fonctionne via InnerSource, les ressources d'ingénierie nécessaires pour construire ces fonctionnalités apparaîtront proportionnellement à leur importance sous la forme de contributeurs invités.
+*InnerSource devient un multiplicateur de force* qui permet à l'équipe hôte d'agir temporairement plus que sa taille réelle pendant les périodes de forte demande.
+Une fois la demande terminée, le débit de l'équipe revient à des niveaux normaux, sans aucune micro-gestion de l'effectif de l'équipe ou des éléments de travail.
+InnerSource permet au temps d'ingénierie de circuler organiquement là où l'organisation en a besoin à un moment donné.
+
+Au-delà du travail brut que l'équipe hôte est capable d'accomplir dans son système, les contributions régulières d'InnerSource donnent à l'équipe hôte *un meilleur alignement des exigences et des priorités avec tous ses consommateurs*.
+Une équipe hôte peut faire sa meilleure collecte d'exigences sur le travail qu'elle produit, mais lorsque le consommateur lui-même est celui qui soumet le travail, les chances sont beaucoup plus grandes que le changement résultant soit aligné sur ce dont le consommateur a besoin.
+Même si c'est une seule équipe d'invités qui soumet le changement, cette équipe est probablement représentative de nombreux autres consommateurs.
+
+En plus de cet alignement, il y a également une formation générale et une éducation de https://innersourcecommons.org/learn/learning-path/contributor/01 [contributeurs] car ils travaillent avec et apprennent de https://innersourcecommons.org/learn/learning-path/trusted-committer/01 [committers de confiance].
+Cette interaction aide les contributeurs à apprendre et à progresser dans leur carrière, ce qui entraîne une *satisfaction professionnelle accrue*.
+La documentation du projet s'améliore pour permettre ces contributions à l'échelle.
+Les contributeurs se sentent concernés par le projet de l'équipe hôte.
+Ils le recommandent à leurs collègues ou aux nouvelles équipes qu'ils rejoignent.
+Ils comprennent mieux le projet et sont en mesure de répondre aux questions des autres, ce qui soulage l'équipe hôte d'une partie de cette charge.
+Un plus grand nombre de personnes contribuant à un projet favorise naturellement l'échange d'idées provenant de toute l'entreprise.
+Au fil du temps, cet apprentissage et cet alignement inter-équipes permettent de "briser les silos traditionnels de l'entreprise".

--- a/introduction/fr/04-avantages.asciidoc
+++ b/introduction/fr/04-avantages.asciidoc
@@ -1,27 +1,27 @@
 == Quels sont les avantages d'InnerSource ?
 
-Il existe de nombreux avantages à collaborer via InnerSource.
-InnerSource offre à une entreprise une stratégie évolutive permettant aux *équipes invitées d'obtenir des demandes de fonctionnalités lorsqu'elles en ont besoin*, sans le fardeau à long terme de la maintenance.
+Il existe de nombreux avantages à collaborer via l'InnerSource.
+L'InnerSource offre à une entreprise une stratégie évolutive permettant aux *équipes invitées d'obtenir des demandes de fonctionnalités lorsqu'elles en ont besoin*, sans le fardeau à long terme de la maintenance.
 L'entreprise dans son ensemble est gagnante car le temps des équipes invitées est mis dans un code que d'autres peuvent utiliser.
 
-Bien que ce résultat soit un avantage indéniable d'InnerSource, il existe de nombreux avantages pour les hôtes qui reçoivent régulièrement des contributions d'InnerSource.
-Rappelez-vous que, dans le cadre du processus d'InnerSource, le propriétaire du produit de l'équipe hôte convient dès le départ que les fonctions contribuées sont bonnes et souhaitables.
+Bien que ce résultat soit un avantage indéniable de l'InnerSource, il existe de nombreux avantages pour les hôtes qui reçoivent régulièrement des contributions via l'InnerSource.
+Rappelez-vous que, dans le cadre du processus de l'InnerSource, le propriétaire du produit de l'équipe hôte convient dès le départ que les fonctions issues des contributions sont bonnes et souhaitables.
 InnerSource permet à l'équipe hôte de recevoir *une aide pour créer un meilleur produit* pour ses consommateurs !
 
-*InnerSource fournit à l'équipe hôte une stratégie évolutive* pour répondre à des quantités variables de fonctionnalités demandées par ses nombreux clients.
+*L'InnerSource fournit à l'équipe hôte une stratégie évolutive* pour répondre à des quantités variables de fonctionnalités demandées par ses nombreux clients.
 Compte tenu de la capacité fixe des membres à temps plein de l'équipe hôte, il est probable que, parfois, les feuilles de route commerciales combinées de ses consommateurs exigent que des quantités très (ou même déraisonnablement) importantes de travail soient effectuées dans les produits de l'équipe hôte.
-Sans InnerSource, cette situation peut facilement conduire à une équipe stressée et surchargée de travail qui doit faire face à de nombreuses demandes de fonctionnalités transmises à ses dirigeants.
+Sans l'InnerSource, cette situation peut facilement conduire une équipe à être stressée et surchargée de travail et qui doit faire face aux nombreuses demandes de fonctionnalités transmises vers ses dirigeants.
 
-Cependant, si l'équipe hôte fonctionne via InnerSource, les ressources d'ingénierie nécessaires pour construire ces fonctionnalités apparaîtront proportionnellement à leur importance sous la forme de contributeurs invités.
-*InnerSource devient un multiplicateur de force* qui permet à l'équipe hôte d'agir temporairement plus que sa taille réelle pendant les périodes de forte demande.
+Cependant, si l'équipe hôte fonctionne via l'InnerSource, les ressources d'ingénierie nécessaires pour construire ces fonctionnalités apparaîtront proportionnellement à leur importance sous la forme de contributeurs invités.
+*L'InnerSource devient un multiplicateur de ressources* qui permet à l'équipe hôte d'agir temporairement plus que sa taille réelle pendant les périodes de forte demande.
 Une fois la demande terminée, le débit de l'équipe revient à des niveaux normaux, sans aucune micro-gestion de l'effectif de l'équipe ou des éléments de travail.
-InnerSource permet au temps d'ingénierie de circuler organiquement là où l'organisation en a besoin à un moment donné.
+L'InnerSource permet au temps d'ingénierie de circuler organiquement là où l'organisation en a besoin à un moment donné.
 
-Au-delà du travail brut que l'équipe hôte est capable d'accomplir dans son système, les contributions régulières d'InnerSource donnent à l'équipe hôte *un meilleur alignement des exigences et des priorités avec tous ses consommateurs*.
-Une équipe hôte peut faire sa meilleure collecte d'exigences sur le travail qu'elle produit, mais lorsque le consommateur lui-même est celui qui soumet le travail, les chances sont beaucoup plus grandes que le changement résultant soit aligné sur ce dont le consommateur a besoin.
+Au-delà du travail brut que l'équipe hôte est capable d'accomplir dans son système, les contributions régulières via l'InnerSource donnent à l'équipe hôte *un meilleur alignement des exigences et des priorités avec tous ses consommateurs*.
+Une équipe hôte peut faire une meilleure collecte d'exigences sur le travail qu'elle produit, mais lorsque le consommateur lui-même est celui qui soumet le travail, les chances sont beaucoup plus grandes que le changement résultant soit aligné sur ce dont le consommateur a besoin.
 Même si c'est une seule équipe d'invités qui soumet le changement, cette équipe est probablement représentative de nombreux autres consommateurs.
 
-En plus de cet alignement, il y a également une formation générale et une éducation de https://innersourcecommons.org/learn/learning-path/contributor/01 [contributeurs] car ils travaillent avec et apprennent de https://innersourcecommons.org/learn/learning-path/trusted-committer/01 [committers de confiance].
+En plus de cet alignement, il y a également une formation générale et une éducation des https://innersourcecommons.org/learn/learning-path/contributor/01 [contributeurs] car ils travaillent avec et apprennent du https://innersourcecommons.org/learn/learning-path/trusted-committer/01 [committers de confiance].
 Cette interaction aide les contributeurs à apprendre et à progresser dans leur carrière, ce qui entraîne une *satisfaction professionnelle accrue*.
 La documentation du projet s'améliore pour permettre ces contributions à l'échelle.
 Les contributeurs se sentent concernés par le projet de l'équipe hôte.

--- a/introduction/fr/04-avantages.asciidoc
+++ b/introduction/fr/04-avantages.asciidoc
@@ -1,4 +1,4 @@
-== Quels sont les avantages d'InnerSource ?
+== Quels sont les avantages de l'InnerSource ?
 
 Il existe de nombreux avantages à collaborer via l'InnerSource.
 L'InnerSource offre à une entreprise une stratégie évolutive permettant aux *équipes invitées d'obtenir des demandes de fonctionnalités lorsqu'elles en ont besoin*, sans le fardeau à long terme de la maintenance.
@@ -6,7 +6,7 @@ L'entreprise dans son ensemble est gagnante car le temps des équipes invitées 
 
 Bien que ce résultat soit un avantage indéniable de l'InnerSource, il existe de nombreux avantages pour les hôtes qui reçoivent régulièrement des contributions via l'InnerSource.
 Rappelez-vous que, dans le cadre du processus de l'InnerSource, le propriétaire du produit de l'équipe hôte convient dès le départ que les fonctions issues des contributions sont bonnes et souhaitables.
-InnerSource permet à l'équipe hôte de recevoir *une aide pour créer un meilleur produit* pour ses consommateurs !
+L'InnerSource permet à l'équipe hôte de recevoir *une aide pour créer un meilleur produit* pour ses consommateurs.
 
 *L'InnerSource fournit à l'équipe hôte une stratégie évolutive* pour répondre à des quantités variables de fonctionnalités demandées par ses nombreux clients.
 Compte tenu de la capacité fixe des membres à temps plein de l'équipe hôte, il est probable que, parfois, les feuilles de route commerciales combinées de ses consommateurs exigent que des quantités très (ou même déraisonnablement) importantes de travail soient effectuées dans les produits de l'équipe hôte.

--- a/introduction/fr/04-avantages.asciidoc
+++ b/introduction/fr/04-avantages.asciidoc
@@ -2,14 +2,14 @@
 
 Il existe de nombreux avantages à collaborer via l'InnerSource.
 L'InnerSource offre à une entreprise une stratégie évolutive permettant aux *équipes invitées d'obtenir des demandes de fonctionnalités lorsqu'elles en ont besoin*, sans le fardeau à long terme de la maintenance.
-L'entreprise dans son ensemble est gagnante car le temps des équipes invitées est mis dans un code que d'autres peuvent utiliser.
+L'entreprise est gagnante dans son ensemble  car le temps des équipes invitées est mis dans du code que d'autres peuvent utiliser.
 
 Bien que ce résultat soit un avantage indéniable de l'InnerSource, il existe de nombreux avantages pour les hôtes qui reçoivent régulièrement des contributions via l'InnerSource.
 Rappelez-vous que, dans le cadre du processus de l'InnerSource, le propriétaire du produit de l'équipe hôte convient dès le départ que les fonctions issues des contributions sont bonnes et souhaitables.
 L'InnerSource permet à l'équipe hôte de recevoir *une aide pour créer un meilleur produit* pour ses consommateurs.
 
 *L'InnerSource fournit à l'équipe hôte une stratégie évolutive* pour répondre à des quantités variables de fonctionnalités demandées par ses nombreux clients.
-Compte tenu de la capacité fixe des membres à temps plein de l'équipe hôte, il est probable que, parfois, les feuilles de route commerciales combinées de ses consommateurs exigent que des quantités très (ou même déraisonnablement) importantes de travail soient effectuées dans les produits de l'équipe hôte.
+Compte tenu de la capacité à faire, fixe, des membres à temps plein de l'équipe hôte, il est probable que, parfois, les feuilles de route commerciales combinées de ses consommateurs exigent que des quantités très (ou même déraisonnablement) importantes de travail soient effectuées dans les produits de l'équipe hôte.
 Sans l'InnerSource, cette situation peut facilement conduire une équipe à être stressée et surchargée de travail et qui doit faire face aux nombreuses demandes de fonctionnalités transmises vers ses dirigeants.
 
 Cependant, si l'équipe hôte fonctionne via l'InnerSource, les ressources d'ingénierie nécessaires pour construire ces fonctionnalités apparaîtront proportionnellement à leur importance sous la forme de contributeurs invités.

--- a/introduction/fr/05-principles.asciidoc
+++ b/introduction/fr/05-principles.asciidoc
@@ -1,0 +1,70 @@
+== Principes d'InnerSource
+
+Chaque entreprise, équipe, projet et individu est différent.
+C'est pourquoi la façon exacte dont le concept d'InnerSource fonctionne varie d'une situation à l'autre.
+Cependant, il existe quatre principes fondamentaux qui forment la base de tout exemple réussi d'InnerSource.
+Ces principes ont été inspirés par des projets open source réussis et sont nécessaires pour qu'InnerSource obtienne les avantages décrits précédemment.
+
+Ces principes sont :
+
+*Openness* (Ouverture)
+*Transparence
+* Mentorat prioritaire
+*Contribution volontaire au code*.
+
+Examinons chacun de ces principes plus en détail.
+
+=== Ouverture
+
+La configuration d'un projet ouvert permet une contribution sans friction.
+Les projets doivent pouvoir être découverts et bien documentés grâce aux fichiers README.md et CONTRIBUTING.md situés à la racine du dépôt.
+Toute personne au sein d'une organisation doit être en mesure de trouver un projet souhaité et d'y participer sans avoir besoin d'une quantité démesurée de conseils directs de la part des membres de l'équipe hôte.
+Les coordonnées de l'équipe hôte doivent être diffusées sur autant de canaux que nécessaire pour le projet.
+L'intention de l'équipe hôte d'accepter les contributions d'InnerSource à son projet devrait être partagée par les canaux pertinents de l'organisation afin de la sensibiliser.
+Particulièrement dans les petites structures, vous pourriez vouloir établir une " diffusion " régulière du travail d'InnerSource effectué par votre équipe.
+Dans les grandes structures, cependant, une telle diffusion peut créer beaucoup de bruit, et il peut être plus approprié de s'assurer que le projet est découvrable dans un outil facile à utiliser.
+Rappelez-vous, l'objectif est de sensibiliser les gens en utilisant les canaux appropriés qui fonctionnent dans VOTRE entreprise.
+
+La liste ci-dessus n'est en aucun cas exhaustive.
+L'ouverture du projet est généralement directement liée à la réussite du projet en termes d'InnerSource.
+Plus il est ouvert, moins il y a de barrières pour les contributeurs potentiels.
+Moins il est ouvert, plus il devient difficile pour quiconque de contribuer.
+
+=== Transparence
+
+Pour que les équipes invitées puissent contribuer de manière significative à un projet, l'équipe hôte doit être _transparente_.
+Cela signifie que les équipes invitées doivent être en mesure de comprendre :
+
+* Le projet/repo et sa direction
+* Les exigences de fonctionnalité en suspens
+* L'avancement des besoins en fonctionnalités
+* La prise de décision de l'équipe hôte
+
+Dans la mesure du possible, les éléments ci-dessus doivent être communiqués clairement et en détail, depuis les définitions internes des équipes jusqu'aux scénarios de cas particuliers propres au projet.
+Cette communication doit être faite d'une manière qui peut être facilement interrogée et comprise par ceux qui ne font pas partie de l'équipe principale.
+
+=== Mentorat hiérarchisé
+
+Le mentorat de l'équipe hôte vers l'équipe invitée via https://innersourcecommons.org/learn/learning-path/trusted-committer/01 [committers de confiance] est un aspect essentiel d'InnerSource.
+https://innersourcecommons.org/learn/learning-path/contributor/01 [Contributeurs] des équipes invitées sont mis à niveau afin qu'ils comprennent suffisamment le projet/repo de l'équipe hôte pour le modifier avec succès.
+Ce faisant, ils en viennent à mieux comprendre le système logiciel de l'équipe hôte en tant que consommateur général et ambassadeur du projet/logiciel.
+Ce contributeur individuel peut, avec le temps et l'expérience, jouer un rôle plus important dans le projet en tant que participant de confiance.
+
+Il est essentiel que l'équipe d'accueil accorde la priorité au mentorat des contributeurs.
+L'équipe hôte doit s'efforcer de prendre le temps d'encadrer les contributeurs invités _au moment où le contributeur en a besoin_ plutôt que lorsque cela lui convient.
+Parfois, il peut s'agir d'un changement de culture pour les ingénieurs de l'équipe hôte qui doivent passer du temps à aider les autres à coder plutôt qu'à coder eux-mêmes.
+Ce mentorat est précieux à la fois pour le contributeur individuel et pour l'hôte, et il vaut la peine de bien le faire.
+Il s'avère mutuellement bénéfique à long terme. En améliorant le code, le contributeur noue ou améliore des relations au sein d'une organisation qui n'aurait peut-être pas pu le faire.
+améliore des relations au sein d'une organisation qui n'auraient peut-être pas existé autrement.
+L'open source reconnaît volontiers ce point et considère comme un honneur d'atteindre le statut de committer de confiance sur un projet.
+
+=== Contribution volontaire au code
+
+Le premier mot _Volontaire_ signifie que l'engagement dans InnerSource des équipes invitées et hôtes se fait de leur plein gré.
+L'équipe invitée donne volontairement du code à l'équipe hôte et l'équipe hôte l'accepte volontairement.
+Cette nature volontaire signifie que chaque équipe doit être certaine que sa participation apporte une valeur ajoutée aux objectifs des autres.
+Une équipe hôte n'est jamais obligée d'accepter une contribution qui n'est pas en parfait accord avec sa mission globale.
+Une équipe invitée n'est jamais tenue de soumettre une contribution qui ne contribue pas à sa propre mission et à ses priorités.
+
+Le mot _Code_ souligne que la collaboration entre l'invité et l'hôte va jusqu'au code.
+La participation des invités à l'ouverture des problèmes, à la mise à jour des exigences, à la correction des documents, etc. est une bonne chose, mais la collaboration doit aller jusqu'à la soumission du code pour obtenir tous les avantages dont nous avons parlé.

--- a/introduction/fr/05-principles.asciidoc
+++ b/introduction/fr/05-principles.asciidoc
@@ -45,26 +45,25 @@ Cette communication doit être faite d'une manière qui peut être facilement in
 
 === Mentorat hiérarchisé
 
-Le mentorat de l'équipe hôte vers l'équipe invitée via https://innersourcecommons.org/learn/learning-path/trusted-committer/01 [committers de confiance] est un aspect essentiel d'InnerSource.
-https://innersourcecommons.org/learn/learning-path/contributor/01 [Contributeurs] des équipes invitées sont mis à niveau afin qu'ils comprennent suffisamment le projet/repo de l'équipe hôte pour le modifier avec succès.
+Le mentorat de l'équipe hôte vers l'équipe invitée via https://innersourcecommons.org/learn/learning-path/trusted-committer/01 [committers de confiance] est un aspect essentiel de l'InnerSource.
+Les https://innersourcecommons.org/learn/learning-path/contributor/01 [Contributeurs] des équipes invitées sont mis à niveau afin qu'ils comprennent suffisamment le projet/repo de l'équipe hôte pour le modifier avec succès.
 Ce faisant, ils en viennent à mieux comprendre le système logiciel de l'équipe hôte en tant que consommateur général et ambassadeur du projet/logiciel.
-Ce contributeur individuel peut, avec le temps et l'expérience, jouer un rôle plus important dans le projet en tant que participant de confiance.
+Ce contributeur individuel peut, avec le temps et l'expérience, jouer un rôle plus important dans le projet en tant que committer de confiance.
 
 Il est essentiel que l'équipe d'accueil accorde la priorité au mentorat des contributeurs.
 L'équipe hôte doit s'efforcer de prendre le temps d'encadrer les contributeurs invités _au moment où le contributeur en a besoin_ plutôt que lorsque cela lui convient.
 Parfois, il peut s'agir d'un changement de culture pour les ingénieurs de l'équipe hôte qui doivent passer du temps à aider les autres à coder plutôt qu'à coder eux-mêmes.
-Ce mentorat est précieux à la fois pour le contributeur individuel et pour l'hôte, et il vaut la peine de bien le faire.
-Il s'avère mutuellement bénéfique à long terme. En améliorant le code, le contributeur noue ou améliore des relations au sein d'une organisation qui n'aurait peut-être pas pu le faire.
-améliore des relations au sein d'une organisation qui n'auraient peut-être pas existé autrement.
+Ce mentorat est précieux à la fois pour le contributeur individuel et pour l'hôte, et ça vaut la peine de bien le faire.
+Il s'avère mutuellement bénéfique à long terme. En améliorant le code, le contributeur noue ou améliore des relations, au sein d'une organisation, qui n'auraient peut-être pas existées autrement.
 L'open source reconnaît volontiers ce point et considère comme un honneur d'atteindre le statut de committer de confiance sur un projet.
 
-=== Contribution volontaire au code
+=== La contribution volontaire au code
 
-Le premier mot _Volontaire_ signifie que l'engagement dans InnerSource des équipes invitées et hôtes se fait de leur plein gré.
+Le mot _Volontaire_ signifie que l'engagement dans l'InnerSource des équipes invitées et hôtes se fait de leur plein gré.
 L'équipe invitée donne volontairement du code à l'équipe hôte et l'équipe hôte l'accepte volontairement.
-Cette nature volontaire signifie que chaque équipe doit être certaine que sa participation apporte une valeur ajoutée aux objectifs des autres.
+Cette inscription de l'équipe dans un aspect volontaire signifie que chaque équipe doit être certaine que son implication apporte de la valeur ajoutée aux objectifs des autres.
 Une équipe hôte n'est jamais obligée d'accepter une contribution qui n'est pas en parfait accord avec sa mission globale.
 Une équipe invitée n'est jamais tenue de soumettre une contribution qui ne contribue pas à sa propre mission et à ses priorités.
 
 Le mot _Code_ souligne que la collaboration entre l'invité et l'hôte va jusqu'au code.
-La participation des invités à l'ouverture des problèmes, à la mise à jour des exigences, à la correction des documents, etc. est une bonne chose, mais la collaboration doit aller jusqu'à la soumission du code pour obtenir tous les avantages dont nous avons parlé.
+L'implication des invités dans l'ouverture des problèmes, la mise à jour des exigences, la correction des documents, etc. est une bonne chose, mais la collaboration doit aller jusqu'à la soumission de code pour obtenir tous les avantages dont nous avons parlé.

--- a/introduction/fr/05-principles.asciidoc
+++ b/introduction/fr/05-principles.asciidoc
@@ -1,16 +1,16 @@
-== Principes d'InnerSource
+== Les principes de l'InnerSource
 
 Chaque entreprise, équipe, projet et individu est différent.
 C'est pourquoi la façon exacte dont le concept d'InnerSource fonctionne varie d'une situation à l'autre.
 Cependant, il existe quatre principes fondamentaux qui forment la base de tout exemple réussi d'InnerSource.
-Ces principes ont été inspirés par des projets open source réussis et sont nécessaires pour qu'InnerSource obtienne les avantages décrits précédemment.
+Ces principes ont été inspirés de projets open source réussis et sont nécessaires pour que l'InnerSource obtienne les avantages décrits précédemment.
 
 Ces principes sont :
 
-*Openness* (Ouverture)
-*Transparence
-* Mentorat prioritaire
-*Contribution volontaire au code*.
+*L'ouverture* (Openness)
+*La transparence
+* Un Mentorat prioritaire
+*La Contribution volontaire au code*
 
 Examinons chacun de ces principes plus en détail.
 

--- a/introduction/fr/06-conclusion.asciidoc
+++ b/introduction/fr/06-conclusion.asciidoc
@@ -8,7 +8,7 @@ Un projet InnerSource réussi implique un https://innersourcecommons.org/learn/l
 Réalisée efficacement, l'InnerSource apporte de nombreux avantages aux deux équipes participantes.
 Les principes clés sur lesquels repose l'efficacité d'InnerSource sont la *contribution volontaire au code* et le *mentorat hiérarchisé*.
 
-Bien que cette formation donne un aperçu de haut niveau de l'InnerSource, il existe de nombreux autres détails utiles pour faire fonctionner l'InnerSource pour votre équipe.
+Bien que cette formation donne un aperçu de haut niveau de l'InnerSource, il existe de nombreux autres détails utiles pour faire fonctionner l'InnerSource avec votre équipe.
 Si vous souhaitez rester connecté à la conversation en cours autour de l'InnerSource et de ses meilleures pratiques, alors rejoignez http://innersourcecommons.org [the InnerSource Commons].
 L'Innersource commons sponsorise un canal Slack, un groupe de travail sur les modèles InnerSource, et plusieurs rencontres en physique chaque année.
 La participation au groupe Innnersource commons est un excellent moyen de rester connecté avec les dernières nouveautés de l'InnerSource.

--- a/introduction/fr/06-conclusion.asciidoc
+++ b/introduction/fr/06-conclusion.asciidoc
@@ -1,0 +1,13 @@
+== Conclusion
+
+Dans ce parcours d'apprentissage, nous avons donné une introduction à InnerSource.
+InnerSource applique les meilleures pratiques et les principes de l'open source au développement de logiciels internes.
+Il offre une option supplémentaire aux consommateurs lorsque les équipes de production ne sont pas en mesure de fournir une demande de fonctionnalité nécessaire.
+Un projet InnerSource réussi implique un https://innersourcecommons.org/learn/learning-path/product-owner/01[_product owner_] et un https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_trusted committer_] de l'équipe *host* ainsi qu'un https://innersourcecommons.org/learn/learning-path/contributor/01[_contributor_] de l'équipe *guest*.
+Réalisée efficacement, InnerSource apporte de nombreux avantages aux deux équipes participantes.
+Les principes clés sur lesquels repose l'efficacité d'InnerSource sont la *contribution volontaire au code* et le *mentorat hiérarchisé*.
+
+Bien que cette formation donne un aperçu de haut niveau d'InnerSource, il existe de nombreux autres détails utiles pour faire fonctionner InnerSource pour votre équipe.
+Si vous souhaitez rester connecté à la conversation en cours autour d'InnerSource et de ses meilleures pratiques, alors rejoignez http://innersourcecommons.org [the InnerSource Commons].
+Le commons sponsorise un canal Slack, un groupe de travail sur les modèles InnerSource, et plusieurs sommets en personne chaque année.
+La participation au commons est un excellent moyen de rester connecté avec les dernières nouveautés d'InnerSource.

--- a/introduction/fr/06-conclusion.asciidoc
+++ b/introduction/fr/06-conclusion.asciidoc
@@ -3,11 +3,11 @@
 Dans ce parcours d'apprentissage, nous avons donné une introduction à InnerSource.
 InnerSource applique les meilleures pratiques et les principes de l'open source au développement de logiciels internes.
 Il offre une option supplémentaire aux consommateurs lorsque les équipes de production ne sont pas en mesure de fournir une demande de fonctionnalité nécessaire.
-Un projet InnerSource réussi implique un https://innersourcecommons.org/learn/learning-path/product-owner/01[_product owner_] et un https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_trusted committer_] de l'équipe *host* ainsi qu'un https://innersourcecommons.org/learn/learning-path/contributor/01[_contributor_] de l'équipe *guest*.
-Réalisée efficacement, InnerSource apporte de nombreux avantages aux deux équipes participantes.
+Un projet InnerSource réussi implique un https://innersourcecommons.org/learn/learning-path/product-owner/01[_product owner_] et un https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_trusted committer_] de l'équipe *hôte* ainsi qu'un https://innersourcecommons.org/learn/learning-path/contributor/01[_contributor_] de l'équipe *invitée*.
+Réalisée efficacement, l'InnerSource apporte de nombreux avantages aux deux équipes participantes.
 Les principes clés sur lesquels repose l'efficacité d'InnerSource sont la *contribution volontaire au code* et le *mentorat hiérarchisé*.
 
-Bien que cette formation donne un aperçu de haut niveau d'InnerSource, il existe de nombreux autres détails utiles pour faire fonctionner InnerSource pour votre équipe.
-Si vous souhaitez rester connecté à la conversation en cours autour d'InnerSource et de ses meilleures pratiques, alors rejoignez http://innersourcecommons.org [the InnerSource Commons].
-Le commons sponsorise un canal Slack, un groupe de travail sur les modèles InnerSource, et plusieurs sommets en personne chaque année.
-La participation au commons est un excellent moyen de rester connecté avec les dernières nouveautés d'InnerSource.
+Bien que cette formation donne un aperçu de haut niveau de l'InnerSource, il existe de nombreux autres détails utiles pour faire fonctionner l'InnerSource pour votre équipe.
+Si vous souhaitez rester connecté à la conversation en cours autour de l'InnerSource et de ses meilleures pratiques, alors rejoignez http://innersourcecommons.org [the InnerSource Commons].
+L'Innersource commons sponsorise un canal Slack, un groupe de travail sur les modèles InnerSource, et plusieurs rencontres en physique chaque année.
+La participation au groupe Innnersource commons est un excellent moyen de rester connecté avec les dernières nouveautés de l'InnerSource.

--- a/introduction/fr/06-conclusion.asciidoc
+++ b/introduction/fr/06-conclusion.asciidoc
@@ -1,7 +1,8 @@
 == Conclusion
 
-Dans ce parcours d'apprentissage, nous avons donné une introduction à InnerSource.
-InnerSource applique les meilleures pratiques et les principes de l'open source au développement de logiciels internes.
+Dans ce parcours d'apprentissage, nous avons proposé une introduction à l'InnerSource.
+L'InnerSource applique les meilleures pratiques et les principes de l'open source au développement de logiciels internes.
+
 Il offre une option supplémentaire aux consommateurs lorsque les équipes de production ne sont pas en mesure de fournir une demande de fonctionnalité nécessaire.
 Un projet InnerSource réussi implique un https://innersourcecommons.org/learn/learning-path/product-owner/01[_product owner_] et un https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_trusted committer_] de l'équipe *hôte* ainsi qu'un https://innersourcecommons.org/learn/learning-path/contributor/01[_contributor_] de l'équipe *invitée*.
 Réalisée efficacement, l'InnerSource apporte de nombreux avantages aux deux équipes participantes.

--- a/introduction/fr/index.md
+++ b/introduction/fr/index.md
@@ -1,0 +1,5 @@
+---
+title: Introduction
+featured: true
+---
+Consultez l'introduction pour en savoir plus sur les types de problèmes pour lesquels InnerSource peut vous aider, sur la façon de procéder, sur les types d'avantages que vous pouvez espérer obtenir en participant et sur les principes sous-jacents qui font que tout fonctionne.


### PR DESCRIPTION
This pull request adds a machine translated version of the introduction section, including the index.ml to French using the DeepL machine translator.

Let's review this for quality if machine translation to french is feasible. Also, we might want to take a look if we can take the free translation service for this or would need to give any attribution to it etc - as well as to the human reviewers obviously.

This addresses #397 