### PR TITLE
Translation-ja: Fix broken links in Japanese translation

### DIFF
--- a/product-owner/ja/01-opening-article-ja.asciidoc
+++ b/product-owner/ja/01-opening-article-ja.asciidoc
@@ -21,5 +21,5 @@ http://innersourcecommons.org/checklist[innersourcecommons.org/checklist] で、
 
 まずは他の動画をご覧ください。
 次のリンクを参照してください。
-アジャイルやリーンプロセスに精通していると役立ちますし、この動画を視る前に、 https://innersourcecommons.org/resources/learningpath/trusted-committer/index[_Trusted Committer_] と https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] の役割を理解しておくことはとても重要です。 
+アジャイルやリーンプロセスに精通していると役立ちますし、この動画を視る前に、 https://innersourcecommons.org/learn/learning-path/trusted-committer/01[_Trusted Committer_] と https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] の役割を理解しておくことはとても重要です。 
 よろしくお願いします。

--- a/trusted-committer/ja/04-uplevelling-community-members-ja.asciidoc
+++ b/trusted-committer/ja/04-uplevelling-community-members-ja.asciidoc
@@ -5,23 +5,23 @@ InnerSourceコミュニティへの参加には連続性があります。
 コミュニティについて知らない人達がいます。
 _新規参加者_ は、コミュニティとその製品に関心があるかもしれませんが、まだそれを使用していません。
 _消費者_ は、ソフトウェアを使用しますが、コントリビューションしていない可能性があります。
-次に、少なくとも一つはコントリビューションをしている https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] がおり、最後にソフトウェアとコミュニティの両方に責任を持つ_Trusted Committers_ がいます。
+次に、少なくとも一つはコントリビューションをしている https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] がおり、最後にソフトウェアとコミュニティの両方に責任を持つ_Trusted Committers_ がいます。
 Trusted Committer としては、この連続性に沿う形で個人を動かし、コントリビューションする能力を高めていく責任があります。
 この意味で、Trusted Committer は、コミュニティにおけるフォースマルチプライヤーとして機能します。
 
 Trusted Committer が、新規参入者や消費者の数を増やすために、自らの製品やコミュニティを宣伝することは重要なことです。
-また、消費者にコントリビューションの機会を伝えて、潜在的な https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] の興味をコミュニティの興味と一致させるようにも努めなければなりません。
-うまく機能する多くは、 https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] が自部門や会社での役割に役立つ何かに取り組むことができる場合です。
+また、消費者にコントリビューションの機会を伝えて、潜在的な https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] の興味をコミュニティの興味と一致させるようにも努めなければなりません。
+うまく機能する多くは、 https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] が自部門や会社での役割に役立つ何かに取り組むことができる場合です。
 開発ツールや自動化が良い例です。
 
-最後に、挑戦的な仕事に取組むことを奨励し、完了に向けて指導することで、成長の可能性がある https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] を見極めてサポートすることは Trusted Commiter の責任です。
+最後に、挑戦的な仕事に取組むことを奨励し、完了に向けて指導することで、成長の可能性がある https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] を見極めてサポートすることは Trusted Commiter の責任です。
 これは、私達の意見では、Trusted Committer の最も崇高な責任であり、Trusted Committer とコントリビューターの両方に価値があるものです。
 Trusted Committers の話によると、メンタリングして人々を見ていくことは、ソフトウェア開発に実際に費やす時間が少ないという事実を補う以上に彼らの能力を向上させているということです。
 
-https://innersourcecommons.org/resources/learningpath/trusted-committer/03/[前の章] で述べたように、学習と個人の成長は、人々がInnerSourceのコミュニティに参加して定着する理由です。
-https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] のレベル向上は、Trsuted Comitterが、コミュニティのスピード、アウトプットそして寿命を向上するために自由に使える最も強力なツールの一つです。
+https://innersourcecommons.org/learn/learning-path/trusted-committer/03/[前の章] で述べたように、学習と個人の成長は、人々がInnerSourceのコミュニティに参加して定着する理由です。
+https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] のレベル向上は、Trsuted Comitterが、コミュニティのスピード、アウトプットそして寿命を向上するために自由に使える最も強力なツールの一つです。
 それは、従業員の企業全体に対する価値を高め、優秀な人材を維持することにもつながることから、従業員のInnerSourceコミュニティへの参加を許可するように経営陣を説得するための重要な論点の1つにもなります。
 
-要約すると、Trusted Committer は、新しい https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] を引きつけ、彼らのコントリビューションする能力を向上させる必要があります。
+要約すると、Trusted Committer は、新しい https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] を引きつけ、彼らのコントリビューションする能力を向上させる必要があります。
 この活動は最終的に、より良いソフトウェアをより早く作成するコミュニティの能力の向上になります。
 そのためには、コントリビューションする機会を伝え、コントリビューターが成長できるように支援したり指導したりします。

--- a/trusted-committer/ja/05-lowering-the-barriers-to-entry-ja.asciidoc
+++ b/trusted-committer/ja/05-lowering-the-barriers-to-entry-ja.asciidoc
@@ -2,17 +2,17 @@
 
 InnerSourceコミュニティでコントリビューションを求めることは、いくつかの理由からオープンソースコミュニティよりも困難です。
 
-* InnerSourceコミュニティでは、潜在的な https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] の数が少ない。
+* InnerSourceコミュニティでは、潜在的な https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] の数が少ない。
 * コントリビュータは、勤務時間内にコントリビューションしたいと考えるため、時間の制約が大きくなる。
 * InnerSourceでの作業は、コントリビュータの正式な目標管理の一部に必ずなるとは限らないため、InnerSourceの作業に費やす時間が目標達成を損なうように見える場合がある。
 
-そのため、Trusted Committersにとって、 https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] のオンボーディングやコントリビューション作成のプロセスを、できるだけスムーズにすることが重要となります。
+そのため、Trusted Committersにとって、 https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] のオンボーディングやコントリビューション作成のプロセスを、できるだけスムーズにすることが重要となります。
 役立つことがいくつかあります。
 
 * 各コードリポジトリに、適切な README.md を用意する。
 適切な README.md には、リポジトリの内容と、その使用目的が説明されています。
 さらに、ライセンスに関する情報も含め、リポジトリ内のソフトウェアの取得、構築、テスト、および使用方法について詳細な手順を提供する必要があります。
-* https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] に期待される事をまとめた CONTRIBTING.md を作成する。
+* https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] に期待される事をまとめた CONTRIBTING.md を作成する。
 それは、次のような一般的な質問に回答する必要があります。
 ** バグレポートや機能リクエストを送付するには、どのようにすれば良いか。
 ** 質問がある時に、誰にどのようにコンタクトすれば良いか。
@@ -24,16 +24,16 @@ InnerSourceコミュニティでコントリビューションを求めること
 
 ソフトウェアに内部ライセンスが添付されている場合には（企業によっては法的エンティティ間でソフトウェアを共有する前提条件）、そのライセンスのコピーと、権利および義務について分かりやすい説明を含めてください。
 
-これら文書化の作業に加えて、オープンソースソフトウェアの開発と同様に、潜在的な https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] によってローカルに開発されるソフトウェアの実行とテストが簡単かつ直ぐに行えるようにすべきです。
+これら文書化の作業に加えて、オープンソースソフトウェアの開発と同様に、潜在的な https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] によってローカルに開発されるソフトウェアの実行とテストが簡単かつ直ぐに行えるようにすべきです。
 それにより可能な限り少ない労力でコントリビューションの実装と検証を開始することができます。
 
 コントリビューションの作成には、 _共有リポジトリ_ と _フォークアンドジョイン_ の2つの共通モデルがあります。
-どちらにも利点があり、Trusted Committerとしては、潜在的および現在の https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] のさまざまなニーズに応えるために両方のモデルをサポートする必要があります。
+どちらにも利点があり、Trusted Committerとしては、潜在的および現在の https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] のさまざまなニーズに応えるために両方のモデルをサポートする必要があります。
 コントリビューターは、コントリビューションプロセスやコミュニティ自体について質問することが多く、これらの質問に回答できる担当者が必要となります。
 したがって、どのようなInnerSourceコミュニティでも、このような質問に回答する担当者が1人以上いることが重要となります。
 通常はTrusted Committerのグループの誰かが担当者になりますが、そうでなければ「オンコール」のコミュニティメンバーがいることを確認する必要があります。
 
-また、潜在的な https://innersourcecommons.org/resources/learningpath/contributor/index[_コントリビューター_] が、どのようなコントリビューションが必要とされているか判断することを支援することも重要です。
+また、潜在的な https://innersourcecommons.org/learn/learning-path/contributor/01[_コントリビューター_] が、どのようなコントリビューションが必要とされているか判断することを支援することも重要です。
 これには、コードのコントリビューションだけでなく、ドキュメントの作成、アートワークの作成、イベントの催しなど、コード以外のコントリビューションも含まれます。
 そのための一般的な方法の一つは、コミュニティが使用するイシュートラッカーで「新人向けタスク」というタグ付けを行うか、コントリビューターが利用できるオープンタスクのマーケットプレイスを実装することです。
 

--- a/trusted-committer/ja/06-advocating-for-the-communitys-needs-ja.asciidoc
+++ b/trusted-committer/ja/06-advocating-for-the-communitys-needs-ja.asciidoc
@@ -14,7 +14,7 @@ Trusted Committerは、組織との信頼関係を構築し、その信頼関係
 彼らには、技術的なリスクとコミュニティ関連のリスクを経営層に伝える責任があります。
 同時に、Trusted Committerは戦略的かつ会社により与えられる自由度の範囲内で活動する必要があります。
 
-また、Trusted Committersは、コミュニティと個々の  https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[コントリビューター] が、彼らの仕事に対する公な称賛を得られるようにする必要があります。
+また、Trusted Committersは、コミュニティと個々の https://innersourcecommons.org/learn/learning-path/contributor/01[コントリビューター] が、彼らの仕事に対する公な称賛を得られるようにする必要があります。
 公な称賛とは、特に自発的にコントリビューションするコントリビューターに与えられ広まるものです。
 有益なコントリビューターを公に称え、彼らのマネージャーがコントリビューションを認識していることを確認することは良い慣行です。
 称賛を与えることを怠ると、個々のコントリビューターを苛立たせ、コミュニティの健全性を損ねることにもなりかねません。
@@ -22,9 +22,9 @@ Trusted Committerは、組織との信頼関係を構築し、その信頼関係
 優れたTrusted Committerは、マネージメント層と連携して公の称賛を主張します。
 称賛を与えないことは、悪意で行われることはほとんどなく、簡単に修正できます。
 
-Trusted Committerによる支持が必要となるもう1つの一般的なケースは、 https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[コントリビューター] にコントリビューションする時間や許可が与えられていない場合です
+Trusted Committerによる支持が必要となるもう1つの一般的なケースは、 https://innersourcecommons.org/learn/learning-path/contributor/01[コントリビューター] にコントリビューションする時間や許可が与えられていない場合です
 これは、コミュニティがコントリビューターの部署外で製品を開発している場合で、マネージャの目標との関係がない場合に起こる可能性があります。
 この場合、Trusted Committer はコントリビュータのマネージャと議論し、代替案の決定を求め働きかける必要があります。
 
-要約すると、Trusted Committerが、個々の https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/01-introduction-article.asciidoc[コントリビューター] とコミュニティ全体の利益を主張する必要がある状況は多々あります。
+要約すると、Trusted Committerが、個々の https://innersourcecommons.org/learn/learning-path/contributor/01[コントリビューター] とコミュニティ全体の利益を主張する必要がある状況は多々あります。
 Trusted Committerは、コミュニティが組織に提供できる価値は、コミュニティの健全性と寿命、そして最終的には両者の信頼関係に依存していることを理解しています。

--- a/trusted-committer/ja/07-becoming-a-trusted-committer-ja.asciidoc
+++ b/trusted-committer/ja/07-becoming-a-trusted-committer-ja.asciidoc
@@ -10,10 +10,10 @@ InnerSourceコミュニティは、オープンソースコミュニティと同
 
 正式にTrusted Committerになるプロセスは、コミュニティごとに異なり、InnerSourceの行路のどこにいるかに依り、時間とともに進化するかもしれません。
 草の根コミュニティでは、創設者がTrusted Committerの役割を担うことが良くあります。
-コミュニティが成長するにつれて、またはより大きなコミュニティでは、Trusted Committerは通常、コミュニティの https://innersourcecommons.org/resources/learningpath/contributor/index[コントリビューター] から指名されたり投票されたりします。
+コミュニティが成長するにつれて、またはより大きなコミュニティでは、Trusted Committerは通常、コミュニティの https://innersourcecommons.org/learn/learning-path/contributor/01[コントリビューター] から指名されたり投票されたりします。
 しかし、Trusted Committerの役割は、成功のために多大な時間と献身を必要とするため、自発的に引き受けなければなりません。
 
-https://innersourcecommons.org/resources/learningpath/contributor/index[コントリビューター] をTrusted Committerの役割に指名する際に適用する基準は何ですか？
+https://innersourcecommons.org/learn/learning-path/contributor/01[コントリビューター] をTrusted Committerの役割に指名する際に適用する基準は何ですか？
 Trusted Committerの役割をうまく果たすには何が必要ですか？
 まず、Trusted Committerの候補は、コミュニティでの活動で、高度な技術力をを示す必要があります。
 それに加えて、コミュニティの仲間や、理想的にはプロダクトオーナーや経営陣とも効果的にコミュニケーションできることを証明していなければなりません。


### PR DESCRIPTION
Recent Japanese translation files have broken links for new site format of InnerSource Commons. This PR fixes them.