### PR TITLE
Updating youtube link

### DIFF
--- a/config/urls.yaml
+++ b/config/urls.yaml
@@ -226,7 +226,7 @@
   video:
     isc: https://innersourcecommons.org/learn/learning-path/contributor/02/
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329500
-    youtube: https://www.youtube.com/watch?v=v3aRZkbTSmY
+    youtube: https://youtu.be/S0Gps2AbZ7M
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/02-becoming-a-contributor-article.asciidoc


### PR DESCRIPTION
Updating the Youtube Link for the Contributor content with the new youtube link of the modified video.

Related to https://github.com/InnerSourceCommons/InnerSourceLearningPath/issues/122