### PR TITLE
Learning path automation

### DIFF
--- a/.github/workflows/publish-to-website.yml
+++ b/.github/workflows/publish-to-website.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - learning-path-automation
+      - master
     paths:
       - .github/workflows/publish-to-website.yml
       - config/urls.yaml

--- a/.github/workflows/publish-to-website.yml
+++ b/.github/workflows/publish-to-website.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.WEBSITE_DEPLOY_KEY }}
           path: ./innersourcecommons.org
-          repository: tsadler1988/innersourcecommons.org
+          repository: InnerSourceCommons/innersourcecommons.org
           fetch-depth: 0
       - name: Branch innersourcecommons.org
         working-directory: innersourcecommons.org

--- a/.github/workflows/publish-to-website.yml
+++ b/.github/workflows/publish-to-website.yml
@@ -1,0 +1,56 @@
+name: Publish to website
+
+env:
+  BRANCH_NAME: publish-latest-learning-path
+
+on:
+  push:
+    branches:
+      - learning-path-automation
+    paths:
+      - .github/workflows/publish-to-website.yml
+      - config/urls.yaml
+      - contributor/**
+      - introduction/**
+      - product-owner/**
+      - scripts/**
+      - trusted-committer/**
+      - workbook/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Learning Path
+        uses: actions/checkout@v2
+        with:
+          path: ./InnerSourceLearningPath
+      - name: Checkout innersourcecommons.org
+        uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.WEBSITE_DEPLOY_KEY }}
+          path: ./innersourcecommons.org
+          repository: tsadler1988/innersourcecommons.org
+          fetch-depth: 0
+      - name: Branch innersourcecommons.org
+        working-directory: innersourcecommons.org
+        run: |
+            git checkout --track origin/$BRANCH_NAME || git checkout -b $BRANCH_NAME
+            git merge -X theirs origin/master --no-edit
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Build
+        working-directory: InnerSourceLearningPath/scripts
+        run: |
+            npm ci
+            TOKEN=${{ secrets.GITHUB_TOKEN }} node generate_learning_path_markdown.js
+            cp -r newsite/. ../../innersourcecommons.org/content/learn/learning-path/
+      - name : Commit
+        working-directory: innersourcecommons.org
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "Update Learning Path articles"
+          git push origin $BRANCH_NAME

--- a/config/urls.yaml
+++ b/config/urls.yaml
@@ -226,7 +226,7 @@
   video:
     isc: https://innersourcecommons.org/learn/learning-path/contributor/02/
     oreilly: https://learning.oreilly.com/learning-paths/learning-path-the/0636920338833/0636920338802-video329500
-    youtube: https://youtu.be/S0Gps2AbZ7M
+    youtube: https://www.youtube.com/watch?v=S0Gps2AbZ7M
   article:
     anchor: ''
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/master/contributor/02-becoming-a-contributor-article.asciidoc


### PR DESCRIPTION
Along with https://github.com/InnerSourceCommons/innersourcecommons.org/pull/130, this fixes #349.

This new GitHub Action will (if relevant files have changed on master):
- Checkout LearningPath and innersourcecommons.org repos
- Checkout or create a `publish-latest-learning-path` branch of innersourcecommons.org
- Run the scripts to generate website markdown from learning path articles and data
- Commit and push to the `publish-latest-learning-path` branch of innersourcecommons.org

Opening a Pull Request will be done a separate action run on innersourcecommons.org repo, due to limitations of GitHub deploy keys (see https://github.com/InnerSourceCommons/innersourcecommons.org/pull/130).

This has been tested against earlier commits, where the action was configured to build from this branch - https://github.com/InnerSourceCommons/InnerSourceLearningPath/actions/workflows/publish-to-website.yml - and the output used to open a PR updating the website - https://github.com/InnerSourceCommons/innersourcecommons.org/pull/134.