### PR TITLE
Changed links to point to proper content

### DIFF
--- a/contributor/01-introduction-article.asciidoc
+++ b/contributor/01-introduction-article.asciidoc
@@ -19,8 +19,8 @@ Finally, some of them may become https://innersourcecommons.org/learn/learning-p
 As a Contributor in an InnerSource community you will interact with people playing other roles of InnerSource, such as https://innersourcecommons.org/learn/learning-path/trusted-committer[_Trusted Committer_] or https://innersourcecommons.org/learn/learning-path/product-owner[_Product Owner_] and possibly with other contributors.
 At times, these roles can be played by the same person, such as Trusted Committer and Product Owner in small grassroots style projects.
 
-This section gives you a very short overview of the other two roles, but we'd like to encourage you to read the https://innersourcecommons.org/learn/learning-path/trusted-committer[introductory article of the Trusted Committer role], and we recommended you read the https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[Lowering the barriers to entry] article, too, before you delve deeper into the details of the Contributor role in this section.
-You can also watch the videos (https://innersourcecommons.org/learn/learning-path/trusted-committer[introduction], https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[lowering the barriers to entry]) instead of reading the articles.
+This section gives you a very short overview of the other two roles, but we'd like to encourage you to read the https://innersourcecommons.org/learn/learning-path/trusted-committer/01/[introductory article of the Trusted Committer role], and we recommended you read the https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[Lowering the barriers to entry] article, too, before you delve deeper into the details of the Contributor role in this section.
+You can also watch the videos (https://innersourcecommons.org/learn/learning-path/trusted-committer/01/[introduction], https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[lowering the barriers to entry]) instead of reading the articles.
 
 ==== Trusted Committer
 

--- a/contributor/de/01-introduction-article-de.asciidoc
+++ b/contributor/de/01-introduction-article-de.asciidoc
@@ -21,8 +21,8 @@ https://innersourcecommons.org/learn/learning-path/trusted-committer[_Trusted Co
 Manchmal übernimmt eine Person mehrere Rollen, z. B. die des Trusted Committer und des Product Owner speziell in kleineren Projekten.
 
 Im Folgenden findest Du einen sehr kurzen Überblick über die anderen Rollen, aber wir möchten Dich ermutigen, die weiterführenden Artikel 
-https://innersourcecommons.org/learn/learning-path/trusted-committer[introductory article of the Trusted Committer role] und https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[Lowering the barriers to entry] zu lesen, bevor Du Dich tiefer in die Details der Contributor Rolle in diesem Abschnitt einarbeitest.
-Alternativ kannst Du Dir auch unsere Videos zu den Themen anschauen: https://innersourcecommons.org/learn/learning-path/trusted-committer[introduction], https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[lowering the barriers to entry].
+https://innersourcecommons.org/learn/learning-path/trusted-committer/01/[introductory article of the Trusted Committer role] und https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[Lowering the barriers to entry] zu lesen, bevor Du Dich tiefer in die Details der Contributor Rolle in diesem Abschnitt einarbeitest.
+Alternativ kannst Du Dir auch unsere Videos zu den Themen anschauen: https://innersourcecommons.org/learn/learning-path/trusted-committer/01/[introduction], https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[lowering the barriers to entry].
 
 ==== Trusted Committer
 

--- a/contributor/it/01-introduction-article-it.asciidoc
+++ b/contributor/it/01-introduction-article-it.asciidoc
@@ -19,8 +19,8 @@ Infine, alcuni di loro possono diventare https://innersourcecommons.org/learn/le
 Come Contributore all'interno di una comunità InnerSource andrai ad interagire con persone che ricoprono altri ruoli InnerSource, come il https://innersourcecommons.org/learn/learning-path/trusted-committer[_Trusted Committer_] o il https://innersourcecommons.org/learn/learning-path/product-owner[_Product Owner_] e possibilmente con altri contributori.
 A volte, questi ruoli possono essere ricoperti dalla stessa persona, come ad esempio il Trusted Committer ed il Product Owner in piccole basi di progetti.
 
-Questa sezione illustra una panoramica molto breve degli altri due ruoli, ma vorremmo incoraggiarti a leggere l'https://innersourcecommons.org/learn/learning-path/trusted-committer[articolo di introduzione del ruolo del Trusted Committer], e raccomandiamo anche di leggere l'articolo su come https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[Abbassare le barriere di ingresso], prima che tu approfondisca i dettagli del ruolo del Contributore in questa sezione.
-Puoi anche guardare i video (https://innersourcecommons.org/learn/learning-path/trusted-committer[introduzione], https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[abbassare le barriere di ingresso]) invece di leggere gli articoli.
+Questa sezione illustra una panoramica molto breve degli altri due ruoli, ma vorremmo incoraggiarti a leggere l'https://innersourcecommons.org/learn/learning-path/trusted-committer/01/[articolo di introduzione del ruolo del Trusted Committer], e raccomandiamo anche di leggere l'articolo su come https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[Abbassare le barriere di ingresso], prima che tu approfondisca i dettagli del ruolo del Contributore in questa sezione.
+Puoi anche guardare i video (https://innersourcecommons.org/learn/learning-path/trusted-committer/01/[introduzione], https://innersourcecommons.org/learn/learning-path/trusted-committer/05/[abbassare le barriere di ingresso]) invece di leggere gli articoli.
 
 ==== Trusted Committer
 

--- a/contributor/zh/01-introduction-zh.asciidoc
+++ b/contributor/zh/01-introduction-zh.asciidoc
@@ -12,7 +12,7 @@
 
 作为 InnerSource 社区中的贡献者，你将与 InnerSource 的其他角色（例如 https://innersourcecommons.org/zh/learn/learning-path/trusted-committer[_Trusted Committer_] 或 https://innersourcecommons.org/zh/learn/learning-path/product-owner[_产品所有者（Product Owner）_] ）进行交互，也可能与其他贡献者进行交互。有时，这些角色可以由同一个人扮演，例如小型基础项目中的“Trusted Committer”和“产品所有者”。
 
-本节为你简要概述了其他两个角色，但我们想鼓励你去阅读 https://innersourcecommons.org/zh/learn/learning-path/trusted-committer[_“Trusted Committer”的介绍文章_] ，也推荐你在深入研究本节的“贡献者”角色之前阅读 https://innersourcecommons.org/zh/learn/learning-path/trusted-committer/05/[_降低准入门槛_] 一文，你也可以观看视频（ https://innersourcecommons.org/zh/learn/learning-path/trusted-committer[_介绍_]、 https://innersourcecommons.org/zh/learn/learning-path/trusted-committer/05/[_降低准入门槛_]）而无需阅读文章。
+本节为你简要概述了其他两个角色，但我们想鼓励你去阅读 https://innersourcecommons.org/zh/learn/learning-path/trusted-committer/01/[_“Trusted Committer”的介绍文章_] ，也推荐你在深入研究本节的“贡献者”角色之前阅读 https://innersourcecommons.org/zh/learn/learning-path/trusted-committer/05/[_降低准入门槛_] 一文，你也可以观看视频（ https://innersourcecommons.org/zh/learn/learning-path/trusted-committer/01/[_介绍_]、 https://innersourcecommons.org/zh/learn/learning-path/trusted-committer/05/[_降低准入门槛_]）而无需阅读文章。
 
 ### Trusted Committer
 


### PR DESCRIPTION
This PR fixes a bug that was introduced in #434 .
In the changed sentence, the link should point to introduction article in trusted committer segment. Because the sentence mentioned a video which is available in the article.
The same change included in #443 for Japanese article.