### PR TITLE
488 publish articles without videos

### DIFF
--- a/config/urls.yaml
+++ b/config/urls.yaml
@@ -72,6 +72,18 @@
     github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/main/introduction/06-conclusion.asciidoc
     isc: https://innersourcecommons.org/learn/learning-path/introduction/06/
     oreilly: ''
+- section: introduction
+  article:
+    anchor: ''
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/main/introduction/07-faq.asciidoc
+    isc: https://innersourcecommons.org/learn/learning-path/introduction/07/
+    oreilly: ''
+- section: introduction
+  article:
+    anchor: ''
+    github: https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/main/introduction/08-is-innersource-right.md
+    isc: https://innersourcecommons.org/learn/learning-path/introduction/08/
+    oreilly: ''
 - section: trusted committer
   video:
     isc: https://innersourcecommons.org/learn/learning-path/trusted-committer/01

--- a/contributor/05-benefits-of-contribution-script.asciidoc
+++ b/contributor/05-benefits-of-contribution-script.asciidoc
@@ -29,7 +29,7 @@ deployment) and communication skills. On the flip side your own impact and
 reputation grows beyond the walls of your own team.
 
 I: Aside from these obvious factors many people observe that being part of an
-Innersource project is perceived as full-filling and fun.
+InnerSource project is perceived as full-filling and fun.
 
 \-> Show team motivation slide.
 

--- a/introduction/02-problems-solved.asciidoc
+++ b/introduction/02-problems-solved.asciidoc
@@ -1,4 +1,4 @@
-== What problems does InnerSource solve?
+== What Problems Does InnerSource Solve?
 
 InnerSource encourages and rewards collaboration and code reuse with anyone, regardless of their position in a company's organizational structure.
 This approach differs from what is seen in traditional organizations where ideas and work product tend to stay trapped within the boundaries of the internal corporate hierarchy and its silos.

--- a/introduction/03-how-works.asciidoc
+++ b/introduction/03-how-works.asciidoc
@@ -1,4 +1,4 @@
-== How does InnerSource work?
+== How Does InnerSource Work?
 
 Let's say that team A uses software produced by team B.
 Team A submits a feature request to team B, but team B isn't able to implement that feature in time for team A.

--- a/introduction/04-benefits.asciidoc
+++ b/introduction/04-benefits.asciidoc
@@ -1,4 +1,4 @@
-== What are the benefits of InnerSource?
+== What Are The Benefits of InnerSource?
 
 There are many benefits to collaborating via InnerSource.
 InnerSource gives a company a scalable strategy for *guest teams to get feature requests when they need them* without the long-term burden of maintenance.

--- a/introduction/05-principles.asciidoc
+++ b/introduction/05-principles.asciidoc
@@ -1,4 +1,4 @@
-== InnerSource principles
+== InnerSource Principles
 
 Every company, team, project, and individual is different.
 Because of that fact, the exact way that the concept of InnerSource works will vary from one situation to another.

--- a/introduction/07-faq.asciidoc
+++ b/introduction/07-faq.asciidoc
@@ -29,7 +29,7 @@ If so then your core team is understaffed. A healthy team is staffed so that the
 You can mitigate this by setting expectation, potentialy via SLAs. If contributors expect PR reviews within an hour, maybe you will be stuck reviewing PRs all the time, but if you set an SLA of 1 day or 1 week, this won't be the case.
 
 === How do we convince management this is a good idea?
-Figure out what they want and get a https://innersourcecommons.org/stories[working example of InnerSource], preferably within your organisation, that shows them getting it. If your organization's OSPO manages innersource projects, reach out to them for support.
+Figure out what they want and get a https://innersourcecommons.org/stories[working example of InnerSource], preferably within your organisation, that shows them getting it. If your organization's OSPO manages InnerSource projects, reach out to them for support.
 
 === How do we convince engineers this is a good idea?
 InnerSource gives engineers the opportunity to develop their career, both in terms of skills and https://patterns.innersourcecommons.org/p/praise-participants[recognition] within their organisation:

--- a/introduction/fr/03-how-works-fr.asciidoc
+++ b/introduction/fr/03-how-works-fr.asciidoc
@@ -1,4 +1,4 @@
-== Comment fonctionne l'Innersource ?
+== Comment fonctionne l'InnerSource ?
 
 Disons que l'équipe A utilise un logiciel produit par l'équipe B.
 L'équipe A soumet une demande de fonctionnalité à l'équipe B, mais l'équipe B n'est pas en mesure d'implémenter cette fonctionnalité à temps pour l'équipe A.

--- a/introduction/fr/06-conclusion-fr.asciidoc
+++ b/introduction/fr/06-conclusion-fr.asciidoc
@@ -10,5 +10,5 @@ Les principes clés sur lesquels repose l'efficacité d'InnerSource sont la *con
 
 Bien que cette formation donne un aperçu de haut niveau de l'InnerSource, il existe de nombreux autres détails utiles pour faire fonctionner l'InnerSource avec votre équipe.
 Si vous souhaitez rester connecté à la conversation en cours autour de l'InnerSource et de ses meilleures pratiques, alors rejoignez http://innersourcecommons.org[the InnerSource Commons].
-L'Innersource commons sponsorise un canal Slack, un groupe de travail sur les modèles InnerSource, et plusieurs rencontres en physique chaque année.
+L'InnerSource commons sponsorise un canal Slack, un groupe de travail sur les modèles InnerSource, et plusieurs rencontres en physique chaque année.
 La participation au groupe Innnersource commons est un excellent moyen de rester connecté avec les dernières nouveautés de l'InnerSource.

--- a/introduction/it/01-introduction-it.asciidoc
+++ b/introduction/it/01-introduction-it.asciidoc
@@ -1,7 +1,7 @@
 == Introduzione
 
 Questa sezione del Learning Path contiene un'introduzione al concetto di InnerSource.
-Innersource è l'applicazione di pratiche e principi open source per lo sviluppo software all'interno dell'azienda.
+InnerSource è l'applicazione di pratiche e principi open source per lo sviluppo software all'interno dell'azienda.
 Il software InnerSource rimane di proprietà dell'azienda, ma internamente è aperto per chiunque lo voglia utilizzare e per chiunque voglia contribuire ad esso.
 Questa strategia consente una collaborazione ampia ed efficace, producendo software agile e reattivo alle mutevoli esigenze dei suoi numerosi stakeholder interni.
 

--- a/scripts/generate_learning_path_markdown.js
+++ b/scripts/generate_learning_path_markdown.js
@@ -8,7 +8,6 @@ const getContributors = require('./get_contributors')
 const mkdirSync = require('./mkdir_sync')
 const getArticleFiles = require('./get_article_files')
 const writeMarkdownFile = require('./write_markdown_file')
-
 const sections = require('./section_data.json')
 
 const urls = YAML.parse(fs.readFileSync(join('..', 'config', 'urls.yaml'), 'utf-8'))
@@ -18,6 +17,13 @@ const getYouTubeCode = (section, articleNumber) => {
   const videoUrls = sectionLinks[articleNumber - 1]
   if (videoUrls && videoUrls.video && videoUrls.video.youtube) {
     return videoUrls.video.youtube.replace('https://www.youtube.com/watch?v=', '')
+  }
+  return ''
+}
+
+const getYouTubeImage = (youTubeCode) => {
+  if (youTubeCode) {
+    return `https://img.youtube.com/vi/${youTubeCode}/mqdefault.jpg`
   }
   return ''
 }
@@ -72,7 +78,7 @@ const getYouTubeCode = (section, articleNumber) => {
         const frontMatter = {
           title: articleTitle,
           contributors,
-          image: `https://img.youtube.com/vi/${youtubeCode}/mqdefault.jpg`,
+          image: getYouTubeImage(youtubeCode),
           featured: weight === 1,
           weight,
           youtubeCode

--- a/scripts/generate_learning_path_markdown.js
+++ b/scripts/generate_learning_path_markdown.js
@@ -14,10 +14,12 @@ const sections = require('./section_data.json')
 const urls = YAML.parse(fs.readFileSync(join('..', 'config', 'urls.yaml'), 'utf-8'))
 
 const getYouTubeCode = (section, articleNumber) => {
-  const firstEntryOfGroupIndex = urls.findIndex(entry => entry.section === section.toLowerCase())
-  const currentPageIndexOffset = articleNumber - 1
-  const youtubeUrl = urls[firstEntryOfGroupIndex + currentPageIndexOffset].video.youtube
-  return youtubeUrl.replace('https://www.youtube.com/watch?v=', '')
+  const sectionLinks = urls.filter(entry => entry.section === section.toLowerCase())
+  const videoUrls = sectionLinks[articleNumber - 1]
+  if (videoUrls && videoUrls.video && videoUrls.video.youtube) {
+    return videoUrls.video.youtube.replace('https://www.youtube.com/watch?v=', '')
+  }
+  return ''
 }
 
 (async () => {


### PR DESCRIPTION
I apologize that my anal nature got the better of me. Nearly all of the files apart from `generate_learning_path_markdown.js` contain capitalization fixes.

As for `generate_learning_path_markdown.js`, I ended up adding a couple of small functions that
- don't assume the article has corresponding video URL entries in the URL config (this was the main bug)
- article title parsing looks for both `.asciidoc` and `.md` syntaxes
There are now enough article-related functions in this file that I'm open to moving them into their own module. It could be overkill though, since all uses are still contained in this script.

I also wonder whether the hard-coded YouTube thumbnail URL (see `getYouTubeImage()`) should be moved to the front-end template instead of here? 

And as always, appreciate any feedback ya'll have on the code too. Its been at least... two years? since I've had hands on code (eep!). 

One silly question I have: what happened to semicolon line endings in JS? Are they just considered hipster throwback punctuation now?