### PR TITLE
Change of publishing path due to i18n support for innersourcecommons.org page

### DIFF
--- a/.github/workflows/publish-to-website.yml
+++ b/.github/workflows/publish-to-website.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
             npm ci
             TOKEN=${{ secrets.GITHUB_TOKEN }} node generate_learning_path_markdown.js
-            cp -r newsite/. ../../innersourcecommons.org/content/learn/learning-path/
+            cp -r newsite/. ../../innersourcecommons.org/content/en/learn/learning-path/
       - name : Commit
         working-directory: innersourcecommons.org
         run: |

--- a/.github/workflows/publish-to-website.yml
+++ b/.github/workflows/publish-to-website.yml
@@ -38,6 +38,8 @@ jobs:
           node-version: 12
       - name: Build
         working-directory: InnerSourceLearningPath/scripts
+        # The automated steps here need to be kept in sync manually with the written instructions at "/scripts/README.md"
+        # ("generate_learning_path_markdown.js" and "How to update innersourcecommons.org with new articles" sections).
         run: |
             npm ci
             TOKEN=${{ secrets.GITHUB_TOKEN }} node generate_learning_path_markdown.js

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,7 +50,7 @@ Anytime there are _any changes_, you need to run the script that generates the u
 3. Is there a whole new Learning Path section? If so:
   * update the ["sections" config](https://github.com/InnerSourceCommons/InnerSourceLearningPath/blob/main/scripts/section_data.json) with the new section and open a pull request for the change
 4. Run **generate_learning_path_markdown.js** as described above.
-4. `cp -r newsite/ <path-to-innersourcecommons.org-repo>/content/learn/learning-path/`.
+4. `cp -r newsite/ <path-to-innersourcecommons.org-repo>/content/en/learn/learning-path/`.
 4. Open a pull request with the modified files in the [InnerSourceCommons/innersourcecommons.org] repo.
 
 [innersourcecommons.org]: https://innersourcecommons.org/


### PR DESCRIPTION
To support i18n at innersourcecommons.org, LearningPath also needs to be partially changed.
This change should or should not be merged depending on the success or failure of the following changes

@rrrutledge, could you check the following PR?
https://github.com/InnerSourceCommons/innersourcecommons.org/pull/412
