### PR TITLE
Spellchecker for English LP content

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,23 @@
+# Uses pyspelling (Aspell).
+# Further info in `.pyspelling.yml`
+name: Spell Check
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - '**.asciidoc'
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  spellcheck:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Check Spelling
+      uses: rojopolis/spellcheck-github-actions@0.29.0

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/node_modules
 scripts/learningpath
 scripts/newsite
 scripts/.env
+wordlist.dic

--- a/.pyspelling.yml
+++ b/.pyspelling.yml
@@ -1,0 +1,41 @@
+# The exceptions below related to asciidocs where adapted from here:
+# https://github.com/devonfw/hangar/blob/master/.spellcheck.yml
+matrix:
+- name: Markdown
+  aspell:
+    lang: en
+    d: en_US
+  dictionary:
+    wordlists:
+    - wordlist.txt
+    output: wordlist.dic
+    encoding: utf-8
+  pipeline:
+  - pyspelling.filters.markdown:
+  - pyspelling.filters.html:
+      comments: true
+      attributes:
+      - title
+      - alt
+      ignores:
+      - ':matches(code, pre)'
+      - 'code'
+      - 'pre'
+  # Ignore for URL starting with http or https
+  - pyspelling.filters.context: 
+      context_visible_first: true
+      delimiters:
+      - open: 'https?:\S+?'
+        close: '\s'
+  # Ignore Image tags
+  - pyspelling.filters.context: 
+      context_visible_first: true
+      delimiters:
+      - open: 'image:[^[]+'
+        close: '\['
+  sources:
+  - 'introduction/[0-9][0-9]*.asciidoc'
+  - 'trusted-committer/[0-9][0-9]*.asciidoc'
+  - 'contributor/[0-9][0-9]*-article.asciidoc'
+  - 'product-owner/[0-9][0-9]*.asciidoc'
+  default_encoding: utf-8

--- a/contributor/05-benefits-of-contribution-article.asciidoc
+++ b/contributor/05-benefits-of-contribution-article.asciidoc
@@ -17,7 +17,7 @@ The most obvious motivation is what typically draws early contributors into open
 source as well.
 
 Remember that annoying bug you've been working around for so long? The time
-and energy that maintainting those workarounds costs? What if instead of waiting for
+and energy that maintaining those workarounds costs? What if instead of waiting for
 the upstream team to fix that issue sometime in the future, you could go ahead
 and fix it yourself? In this "scratch your own itch" situation first-time contributors
 often start with fixing issues in projects they depend on for their

--- a/introduction/07-faq.asciidoc
+++ b/introduction/07-faq.asciidoc
@@ -26,7 +26,7 @@ image::https://user-images.githubusercontent.com/9609562/151901209-52b3468b-dedd
 === Will we just be reviewing PRs all day every day?
 If so then your core team is understaffed. A healthy team is staffed so that there is time for assisting contributors and making core contributions yourself.
 
-You can mitigate this by setting expectation, potentialy via SLAs. If contributors expect PR reviews within an hour, maybe you will be stuck reviewing PRs all the time, but if you set an SLA of 1 day or 1 week, this won't be the case.
+You can mitigate this by setting expectation, potentially via SLAs. If contributors expect PR reviews within an hour, maybe you will be stuck reviewing PRs all the time, but if you set an SLA of 1 day or 1 week, this won't be the case.
 
 === How do we convince management this is a good idea?
 Figure out what they want and get a https://innersourcecommons.org/stories[working example of InnerSource], preferably within your organisation, that shows them getting it. If your organization's OSPO manages InnerSource projects, reach out to them for support.
@@ -41,7 +41,7 @@ InnerSource gives engineers the opportunity to develop their career, both in ter
 Also, many engineers value open source; InnerSource embraces open source practices, and can be a step towards open source for many projects.
 
 === What are the expectations on part of both host and contributor?
-Work together! This may be completely async via Pull Requests, or invovle regular community catchups - whatever works for you.
+Work together! This may be completely async via Pull Requests, or involve regular community catchups - whatever works for you.
 
 Communication and support must go in both directions and be open and collaborative, fostering a culture of psychological safety. Feedback on contributions, or existing code, must be approached with a growth mindset, and as partnership to make things better.
 

--- a/introduction/08-is-innersource-right.asciidoc
+++ b/introduction/08-is-innersource-right.asciidoc
@@ -23,7 +23,7 @@ You will need to encourage and support contributions via activities such as:
 * Inviting users to make the contributions that they need and following up with them to ensure that they do them.
 * Maintaining an https://patterns.innersourcecommons.org/p/base-documentation#contributing.md[CONTRIBUTING.md] document that contains everything an engineer needs to know to contribute to the project.
 * Giving up-front guidance and direction as to how to implement a given contribution.
-* Being available during regular hours for any ad-hoc questions that contributors have.
+* Being available during regular hours for any ad hoc questions that contributors have.
 * Timely review of incoming pull requests.
 * Ongoing maintenance of submitted code (after the https://patterns.innersourcecommons.org/p/30-day-warranty[warranty window]).
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -1,0 +1,72 @@
+# --------------------------
+# Extra words for the Learning Path
+# --------------------------
+
+# From chapter: Introduction
+scalable
+PRs
+SLAs
+OSPO
+upleveled
+async
+catchups
+InnerSource
+skillset
+mentorship
+codebase
+SLA
+roadmap
+roadmaps
+repo
+README
+discoverable
+md
+hoc
+
+# From chapter: Trusted Committer
+onboarding
+uplevel
+Committer's
+Committer’s
+frictionless
+noncode
+
+# From chapter: Contributor
+repos
+Jira
+UX
+WIP
+OSS
+reimplementing
+reimplement
+upleveling
+hacky
+reviewability
+searchability
+CEST
+amongst
+linkable
+UI
+
+# From chapter: Product Owner
+integrations
+O'Reilly
+UPE
+findability
+refactorization
+ALM
+FDI
+LinkedIn
+Bonewald
+Silona
+Code-a-Thon
+modularization
+Lifecycle
+TCs
+
+# British - should be replaced by American equivalents
+organises
+organisation
+organisational
+organisation's
+learnt


### PR DESCRIPTION
I added a basic setup for a GitHub Action that runs a spellchecker for the LP content.
This is modelled after a very similar approach that we are just introducing for our Patterns (see https://github.com/InnerSourceCommons/InnerSourcePatterns/pull/519).

A key difference here is that the tool used here, pyspelling, does seem to work a bit better with markdown, than it works with asciidocs. However I tweaked the configuration based on [an example](https://github.com/devonfw/hangar/blob/master/.spellcheck.yml) that I found, and it looks like it works well enough.

To judge the effect of the spellchecker, please compare the results of the [1st run](https://github.com/InnerSourceCommons/InnerSourceLearningPath/actions/runs/3915131601/jobs/6692970788), with the [2nd run](https://github.com/InnerSourceCommons/InnerSourceLearningPath/actions/runs/3915158590/jobs/6693033888). Before the 2nd run I had already fixed a couple of obvious spelling errors.

Left to do:

- decide if you like this approach
- decide if you want to spellcheck for en_US (so American English). if yes, remove the last block in `wordlist.txt` and fix the respective spellings (mostly just the word "organisation" 😄)
- improve the config in `.pyspelling.yml` and the `wordlist.txt`, so that the spellchecker passes on the current content (adapting the failing parts of the content is of course also another way to fix this)
- decide where to place the config files - they could be placed in some folder, if you don't want them in your root

I am happy to answer your questions. Just note, that I am only using pyspelling/aspell for a couple of days myself now :)


