### PR TITLE
528-article-default-image

### DIFF
--- a/scripts/generate_learning_path_markdown.js
+++ b/scripts/generate_learning_path_markdown.js
@@ -21,11 +21,11 @@ const getYouTubeCode = (section, articleNumber) => {
   return ''
 }
 
-const getYouTubeImage = (youTubeCode) => {
+const getArticleImage = (youTubeCode) => {
   if (youTubeCode) {
     return `https://img.youtube.com/vi/${youTubeCode}/mqdefault.jpg`
   }
-  return ''
+  return 'images/learn/LP-article-default.png'
 }
 
 (async () => {
@@ -77,7 +77,7 @@ const getYouTubeImage = (youTubeCode) => {
         const frontMatter = {
           title: articleTitle,
           contributors,
-          image: getYouTubeImage(youtubeCode),
+          image: getArticleImage(youtubeCode),
           featured: weight === 1,
           weight,
           youtubeCode

--- a/scripts/get_article_files.js
+++ b/scripts/get_article_files.js
@@ -4,7 +4,7 @@ const { join } = require('path')
 module.exports = getArticleFiles = (path) => {
   return fs.readdirSync(path).reduce((articles, filename) => {
     const filePath = join(path, filename)
-    if (filePath.match(/\d\d/) && !filePath.includes('-script.asciidoc')) {
+    if (filePath.match(/\d\d[-\w]+(?<!script)\.asciidoc/)) {
       return [...articles, {
         filePath,
         asciiDoc: fs.readFileSync(filePath, 'utf-8')


### PR DESCRIPTION
This PR does two things:

 1. Fixes a bug where the new VTT caption files were being considered articles, causing the site generation script to x_x.
 2. Any articles without YouTube videos will now reference a default image.

Related to Issue #528 

The actual image is included in a sister PR in the innersourcecommons.org repository: https://github.com/InnerSourceCommons/innersourcecommons.org/pull/468
