### PR TITLE
Fix user tile bug

### DIFF
--- a/scripts/get_contributors.js
+++ b/scripts/get_contributors.js
@@ -92,6 +92,8 @@ module.exports = async function (filepath) {
   return Object.values(
     [...authors, ...reviewers].reduce((accumulator, user) => {
       // Dedupe users
+      // Some user objects do not have a URL (can't figure out why).
+      // In that case, copy over a good URL instead.
       const newUser = accumulator[user.name] || user
       newUser.url = newUser.url || user.url
       accumulator[user.name] = newUser

--- a/scripts/get_contributors.js
+++ b/scripts/get_contributors.js
@@ -92,7 +92,10 @@ module.exports = async function (filepath) {
   return Object.values(
     [...authors, ...reviewers].reduce((accumulator, user) => {
       // Dedupe users
-      accumulator[user.name] = user
+      const newUser = accumulator[user.name] || user
+      newUser.url = newUser.url || user.url
+      accumulator[user.name] = newUser
+
       return accumulator
     }, {})
   )


### PR DESCRIPTION
* For some reason, some author objects in the graph API are missing a user object (and subsequently a user URL).
* Users without a URL don't get a link to their GitHub profile.
* Fix is to explicitly ensure that we don't overwrite a good user URL with an empty one.
* See https://github.com/InnerSourceCommons/InnerSourceLearningPath/issues/536