### PR TITLE
Bot user should not show as contributor

### DIFF
--- a/scripts/get_contributors.js
+++ b/scripts/get_contributors.js
@@ -89,14 +89,18 @@ module.exports = async function (filepath) {
     })
   })
 
+  // Dedupe users
   return Object.values(
     [...authors, ...reviewers].reduce((accumulator, user) => {
-      // Dedupe users
-      // Some user objects do not have a URL (can't figure out why).
-      // In that case, copy over a good URL instead.
-      const newUser = accumulator[user.name] || user
-      newUser.url = newUser.url || user.url
-      accumulator[user.name] = newUser
+      // Skip bot users
+      if (!user.name.includes('[bot]')) {
+        // Some user objects do not have a URL (can't figure out why).
+        // In that case, copy over a good URL instead.
+        const newUser = accumulator[user.name] || user
+        newUser.url = newUser.url || user.url
+
+        accumulator[user.name] = newUser
+      }
 
       return accumulator
     }, {})


### PR DESCRIPTION
* Filter bot users out of contributors list.
* You can see the bot user missing from the list of contributors on the (local) left article with these changes, whereas it is present on the right that does not have these changes.  https://innersourcecommons.org/it/learn/learning-path/trusted-committer/01/
* Resolves https://github.com/InnerSourceCommons/InnerSourceLearningPath/issues/556.

![image](https://github.com/InnerSourceCommons/InnerSourceLearningPath/assets/9609562/7934a5db-cf81-4b9b-b7c4-f88ff382d35d)
