### PR TITLE
Added concurrency section to Publish Website workflow (Issue 575)

### DIFF
--- a/.github/workflows/publish-to-website.yml
+++ b/.github/workflows/publish-to-website.yml
@@ -14,6 +14,11 @@ on:
       - trusted-committer/**
       - workbook/**
 
+# Checks if this workflow is already running, and if so cancels it
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When builds are triggered within about 4 min of each other, the parallel calls to GitHub's GraphQL API clobber one another. Even with a throttling helper, the clobbering results in a too-many-requests API error, and the build fails.

This small change should hopefully prevent this error in the future. It will check if the build/workflow is already running, and if so, cancels it. If there are multiple builds in quick succession, only the latest one will publish. 
